### PR TITLE
feat: change token type name (kabu -> share)

### DIFF
--- a/app/bond/forms.py
+++ b/app/bond/forms.py
@@ -651,9 +651,9 @@ class RequestSignatureForm(Form):
 # 権利移転（募集申込）
 class TransferForm(Form):
     token_address = StringField(
-        "債券アドレス",
+        "トークンアドレス",
         validators=[
-            DataRequired('債券アドレスは必須です。')
+            DataRequired('トークンアドレスは必須です。')
         ]
     )
 
@@ -680,7 +680,7 @@ class TransferForm(Form):
 
     def validate_token_address(self, field):
         if not Web3.isAddress(field.data):
-            raise ValidationError('債券アドレスは無効なアドレスです。')
+            raise ValidationError('トークンアドレスは無効なアドレスです。')
 
     def validate_to_address(self, field):
         if not Web3.isAddress(field.data):
@@ -690,9 +690,9 @@ class TransferForm(Form):
 # 募集申込割当
 class AllotForm(Form):
     token_address = StringField(
-        "債券アドレス",
+        "トークンアドレス",
         validators=[
-            DataRequired('債券アドレスは必須です。')
+            DataRequired('トークンアドレスは必須です。')
         ]
     )
     to_address = StringField(

--- a/app/bond/views.py
+++ b/app/bond/views.py
@@ -112,7 +112,7 @@ def map_interest_payment_date(form, interestPaymentDate):
 
 
 ####################################################
-# [債券]トークン名取得
+# トークン名取得
 ####################################################
 @bond.route('/get_token_name/<string:token_address>', methods=['GET'])
 @login_required
@@ -126,7 +126,7 @@ def get_token_name(token_address):
 
 
 ####################################################
-# [債券]新規発行
+# 新規発行
 ####################################################
 
 @bond.route('/issue', methods=['GET', 'POST'])
@@ -281,7 +281,7 @@ def issue():
 
 
 ####################################################
-# [債券]発行済一覧
+# 発行済一覧
 ####################################################
 @bond.route('/list', methods=['GET'])
 @login_required
@@ -335,7 +335,7 @@ def list():
 
 
 ####################################################
-# [債券]保有者一覧
+# 保有者一覧
 ####################################################
 @bond.route('/holders/<string:token_address>', methods=['GET'])
 @login_required
@@ -561,7 +561,7 @@ def get_holders(token_address: str) -> Dict:
 
 
 ####################################################
-# [債券]保有者リスト履歴
+# 保有者リスト履歴
 ####################################################
 @bond.route('/holders_csv_history/<string:token_address>', methods=['GET'])
 @login_required
@@ -647,7 +647,7 @@ def holders_csv_history_download():
 
 
 ####################################################
-# [債券]保有者移転
+# 保有者移転
 ####################################################
 @bond.route('/transfer_ownership/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required
@@ -708,7 +708,7 @@ def transfer_ownership(token_address, account_address):
 
 
 ####################################################
-# [債券]保有者詳細
+# 保有者詳細
 ####################################################
 @bond.route('/holder/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required
@@ -790,7 +790,7 @@ def holder(token_address, account_address):
 
 
 ####################################################
-# [債券]設定内容修正
+# 設定内容修正
 ####################################################
 @bond.route('/setting/<string:token_address>', methods=['GET', 'POST'])
 @login_required
@@ -1027,7 +1027,7 @@ def setting(token_address: ChecksumAddress):
 
 
 ####################################################
-# [債券]第三者認定申請
+# 第三者認定申請
 ####################################################
 @bond.route('/request_signature/<string:token_address>', methods=['GET', 'POST'])
 @login_required
@@ -1183,7 +1183,7 @@ def corporate_bond_ledger_template(token_address):
 
 
 ####################################################
-# [債券]公開
+# 公開
 ####################################################
 @bond.route('/release', methods=['POST'])
 @login_required
@@ -1215,7 +1215,7 @@ def release():
 
 
 ####################################################
-# [債券]償還
+# 償還
 ####################################################
 @bond.route('/redeem', methods=['POST'])
 @login_required
@@ -1239,7 +1239,7 @@ def redeem():
 
 
 ####################################################
-# [債券]追加発行
+# 追加発行
 ####################################################
 @bond.route('/add_supply/<string:token_address>', methods=['GET', 'POST'])
 @login_required
@@ -1290,7 +1290,7 @@ def add_supply(token_address):
 
 
 ####################################################
-# [債券]保有一覧
+# 保有一覧
 ####################################################
 @bond.route('/positions', methods=['GET'])
 @login_required
@@ -1392,7 +1392,7 @@ def positions():
 
 
 ####################################################
-# [債券]売出
+# 売出
 ####################################################
 @bond.route('/sell/<string:token_address>', methods=['GET', 'POST'])
 @login_required
@@ -1503,7 +1503,7 @@ def sell(token_address):
 
 
 ####################################################
-# [債券]売出停止
+# 売出停止
 ####################################################
 @bond.route('/cancel_order/<string:token_address>/<int:order_id>', methods=['GET', 'POST'])
 @login_required
@@ -1555,7 +1555,7 @@ def cancel_order(token_address, order_id):
 
 
 ####################################################
-# [債券]募集申込開始/停止
+# 募集申込開始/停止
 ####################################################
 @bond.route('/start_initial_offering', methods=['POST'])
 @login_required
@@ -1598,7 +1598,7 @@ def _set_offering_status(token_address, status):
 
 
 ####################################################
-# [債券]募集申込一覧
+# 募集申込一覧
 ####################################################
 # 申込一覧画面
 @bond.route('/applications/<string:token_address>', methods=['GET'])
@@ -1713,7 +1713,7 @@ def get_applications(token_address):
 
 
 ####################################################
-# [債券]割当登録
+# 割当登録
 ####################################################
 @bond.route('/allot/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required
@@ -1764,7 +1764,7 @@ def allot(token_address, account_address):
 
 
 ####################################################
-# [債券]権利移転（募集申込）
+# 権利移転（募集申込）
 ####################################################
 @bond.route('/transfer_allotment/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required

--- a/app/coupon/forms.py
+++ b/app/coupon/forms.py
@@ -48,10 +48,10 @@ class IssueCouponForm(Form):
     yyyymmdd_regexp = '^(19[0-9]{2}|20[0-9]{2})(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])$'
 
     name = StringField(
-        "クーポン名 *",
+        "名称 *",
         validators=[
-            DataRequired('クーポン名は必須です。'),
-            Length(min=1, max=100, message='クーポン名は100文字以内で入力してください。')
+            DataRequired('名称は必須です。'),
+            Length(min=1, max=100, message='名称は100文字以内で入力してください。')
         ]
     )
 
@@ -177,7 +177,7 @@ class IssueCouponForm(Form):
 
 class SettingCouponForm(Form):
     token_address = StringField("トークンアドレス", validators=[])
-    name = StringField("クーポン名", validators=[])
+    name = StringField("名称", validators=[])
     symbol = StringField("略称", validators=[])
     totalSupply = IntegerField("総発行量", validators=[])
     expirationDate = StringField("有効期限", validators=[])
@@ -269,7 +269,7 @@ class SettingCouponForm(Form):
 
 class AddSupplyForm(Form):
     token_address = StringField("トークンアドレス", validators=[])
-    name = StringField("クーポン名", validators=[])
+    name = StringField("名称", validators=[])
     totalSupply = IntegerField("総発行量", validators=[])
     addSupply = IntegerField(
         "追加発行量",
@@ -287,9 +287,9 @@ class AddSupplyForm(Form):
 
 class TransferForm(Form):
     token_address = StringField(
-        "クーポンアドレス",
+        "トークンアドレス",
         validators=[
-            DataRequired('クーポンアドレスは必須です。')
+            DataRequired('トークンアドレスは必須です。')
         ]
     )
 

--- a/app/coupon/views.py
+++ b/app/coupon/views.py
@@ -914,7 +914,7 @@ def transfer():
         if form.validate():
             # Addressフォーマットチェック（token_address）
             if not Web3.isAddress(form.token_address.data):
-                flash('クーポンアドレスは有効なアドレスではありません。', 'error')
+                flash('トークンアドレスは有効なアドレスではありません。', 'error')
                 return render_template('coupon/transfer.html', form=form)
 
             # Addressフォーマットチェック（send_address）
@@ -927,7 +927,7 @@ def transfer():
             if token is None or \
                     token.template_id != Config.TEMPLATE_ID_COUPON or \
                     token.admin_address != session['eth_account'].lower():
-                flash('無効なクーポンアドレスです。', 'error')
+                flash('無効なトークンアドレスです。', 'error')
                 return render_template('coupon/transfer.html', form=form)
             token_abi = json.loads(token.abi.replace("'", '"').replace('True', 'true').replace('False', 'false'))
             TokenContract = web3.eth.contract(address=token.token_address, abi=token_abi)
@@ -1097,7 +1097,7 @@ def get_usage_history(token_address):
     if token is None:
         abort(404)
 
-    # クーポントークンの消費イベント（Consume）を検索
+    # トークンの消費イベント（Consume）を検索
     # Note: token_addressに対して、Couponトークンのものであるかはチェックしていない。
     entries = Consume.query.filter(Consume.token_address == token_address).all()
 
@@ -1131,7 +1131,7 @@ def used_csv_download():
 
     token_name = json.loads(get_token_name(token_address).data)
 
-    # クーポントークンの消費イベント（Consume）を検索
+    # トークンの消費イベント（Consume）を検索
     entries = Consume.query.filter(Consume.token_address == token_address).all()
 
     # リスト作成

--- a/app/membership/forms.py
+++ b/app/membership/forms.py
@@ -325,9 +325,9 @@ class CancelOrderForm(Form):
 
 class TransferForm(Form):
     token_address = StringField(
-        "会員権アドレス",
+        "トークンアドレス",
         validators=[
-            DataRequired('会員権アドレスは必須です。')
+            DataRequired('トークンアドレスは必須です。')
         ]
     )
 

--- a/app/membership/views.py
+++ b/app/membership/views.py
@@ -74,7 +74,7 @@ def transfer_token(token_contract, from_address, to_address, amount):
 
 
 ####################################################
-# [会員権]発行済一覧
+# 発行済一覧
 ####################################################
 @membership.route('/list', methods=['GET'])
 @login_required
@@ -130,7 +130,7 @@ def list():
 
 
 ####################################################
-# [会員権]トークン追跡
+# トークン追跡
 ####################################################
 @membership.route('/token/track/<string:token_address>', methods=['GET'])
 @login_required
@@ -239,7 +239,7 @@ def token_tracker_csv():
 
 
 ####################################################
-# [会員権]募集申込一覧
+# 募集申込一覧
 ####################################################
 # 申込一覧画面
 @membership.route('/applications/<string:token_address>', methods=['GET'])
@@ -337,7 +337,7 @@ def get_applications(token_address):
 
 
 ####################################################
-# [会員権]割当（募集申込）
+# 割当（募集申込）
 ####################################################
 @membership.route('/allocate/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required
@@ -395,7 +395,7 @@ def allocate(token_address, account_address):
 
 
 ####################################################
-# [会員権]保有者一覧
+# 保有者一覧
 ####################################################
 @membership.route('/holders/<string:token_address>', methods=['GET'])
 @login_required
@@ -587,7 +587,7 @@ def get_token_name(token_address):
 
 
 ####################################################
-# [会員権]保有者リスト履歴
+# 保有者リスト履歴
 ####################################################
 @membership.route('/holders_csv_history/<string:token_address>', methods=['GET'])
 @login_required
@@ -673,7 +673,7 @@ def holders_csv_history_download():
 
 
 ####################################################
-# [会員権]保有者移転
+# 保有者移転
 ####################################################
 @membership.route('/transfer_ownership/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required
@@ -735,7 +735,7 @@ def transfer_ownership(token_address, account_address):
 
 
 ####################################################
-# [会員権]保有者詳細
+# 保有者詳細
 ####################################################
 @membership.route('/holder/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required
@@ -806,7 +806,7 @@ def holder(token_address, account_address):
 
 
 ####################################################
-# [会員権]設定内容修正
+# 設定内容修正
 ####################################################
 @membership.route('/setting/<string:token_address>', methods=['GET', 'POST'])
 @login_required
@@ -973,7 +973,7 @@ def setting(token_address):
 
 
 ####################################################
-# [会員権]公開
+# 公開
 ####################################################
 @membership.route('/release', methods=['POST'])
 @login_required
@@ -1003,7 +1003,7 @@ def release():
 
 
 ####################################################
-# [会員権]新規発行
+# 新規発行
 ####################################################
 @membership.route('/issue', methods=['GET', 'POST'])
 @login_required
@@ -1080,7 +1080,7 @@ def issue():
 
 
 ####################################################
-# [会員権]保有一覧（売出管理画面）
+# 保有一覧（売出管理画面）
 ####################################################
 @membership.route('/positions', methods=['GET'])
 @login_required
@@ -1180,7 +1180,7 @@ def positions():
 
 
 ####################################################
-# [会員権]売出
+# 売出
 ####################################################
 @membership.route('/sell/<string:token_address>', methods=['GET', 'POST'])
 @login_required
@@ -1262,7 +1262,7 @@ def sell(token_address):
 
 
 ####################################################
-# [会員権]売出停止
+# 売出停止
 ####################################################
 @membership.route('/cancel_order/<string:token_address>/<int:order_id>', methods=['GET', 'POST'])
 @login_required
@@ -1312,7 +1312,7 @@ def cancel_order(token_address, order_id):
 
 
 ####################################################
-# [会員権]追加発行
+# 追加発行
 ####################################################
 @membership.route('/add_supply/<string:token_address>', methods=['GET', 'POST'])
 @login_required
@@ -1353,7 +1353,7 @@ def add_supply(token_address):
 
 
 ####################################################
-# [会員権]有効化/無効化
+# 有効化/無効化
 ####################################################
 @membership.route('/valid', methods=['POST'])
 @login_required
@@ -1394,7 +1394,7 @@ def _set_validity(token_address, isvalid):
 
 
 ####################################################
-# [会員権]募集申込開始/停止
+# 募集申込開始/停止
 ####################################################
 @membership.route('/start_initial_offering', methods=['POST'])
 @login_required
@@ -1707,7 +1707,7 @@ def bulk_transfer_approval(upload_id):
 
 
 ####################################################
-# [会員権]権限エラー
+# 権限エラー
 ####################################################
 @membership.route('/PermissionDenied', methods=['GET', 'POST'])
 @login_required

--- a/app/models.py
+++ b/app/models.py
@@ -189,13 +189,13 @@ class Issuer(db.Model):
     personal_info_contract_address = db.Column(db.String(42))
     # トークンリストコントラクトアドレス
     token_list_contract_address = db.Column(db.String(42))
-    # 株式取引コントラクトアドレス
+    # SHARE取引コントラクトアドレス
     ibet_share_exchange_contract_address = db.Column(db.String(42))
-    # 債券取引コントラクトアドレス
+    # BOND取引コントラクトアドレス
     ibet_sb_exchange_contract_address = db.Column(db.String(42))
-    # 会員権取引コントラクトアドレス
+    # MEMBERSHIP取引コントラクトアドレス
     ibet_membership_exchange_contract_address = db.Column(db.String(42))
-    # クーポン取引コントラクトアドレス
+    # COUPON取引コントラクトアドレス
     ibet_coupon_exchange_contract_address = db.Column(db.String(42))
     # EOA keyfileのパスワード（暗号化済）
     # deferredで暗号化情報が必要なとき以外はDBから取得しないようにする
@@ -305,7 +305,7 @@ class BulkTransfer(db.Model):
 
 
 class Certification(db.Model):
-    """債券認定依頼"""
+    """認定依頼"""
     __tablename__ = 'certification'
 
     # シーケンスID

--- a/app/share/forms.py
+++ b/app/share/forms.py
@@ -415,9 +415,9 @@ class TransferOwnershipForm(Form):
 # 割当
 class TransferForm(Form):
     token_address = StringField(
-        "株式アドレス",
+        "トークンアドレス",
         validators=[
-            DataRequired('株式アドレスは必須です。')
+            DataRequired('トークンアドレスは必須です。')
         ]
     )
 
@@ -446,9 +446,9 @@ class TransferForm(Form):
 # 募集申込割当
 class AllotForm(Form):
     token_address = StringField(
-        "株式アドレス",
+        "トークンアドレス",
         validators=[
-            DataRequired('株式アドレスは必須です。')
+            DataRequired('トークンアドレスは必須です。')
         ]
     )
     to_address = StringField(

--- a/app/share/views.py
+++ b/app/share/views.py
@@ -102,7 +102,7 @@ def flash_errors(form: Form):
 
 
 ####################################################
-# [株式]トークン名取得
+# トークン名取得
 ####################################################
 @share.route('/get_token_name/<string:token_address>', methods=['GET'])
 @login_required
@@ -115,7 +115,7 @@ def get_token_name(token_address):
 
 
 ####################################################
-# [株式]新規発行
+# 新規発行
 ####################################################
 @share.route('/issue', methods=['GET', 'POST'])
 @login_required
@@ -237,7 +237,7 @@ def issue():
 
 
 ####################################################
-# [株式]発行済一覧
+# 発行済一覧
 ####################################################
 @share.route('/list', methods=['GET'])
 @login_required
@@ -290,7 +290,7 @@ def list():
 
 
 ####################################################
-# [株式]設定内容修正
+# 設定内容修正
 ####################################################
 @share.route('/setting/<string:token_address>', methods=['GET', 'POST'])
 @login_required
@@ -517,7 +517,7 @@ def setting(token_address):
 
 
 ####################################################
-# [株式]公開
+# 公開
 ####################################################
 @share.route('/release', methods=['POST'])
 @login_required
@@ -549,7 +549,7 @@ def release():
 
 
 ####################################################
-# [株式]募集申込開始/停止
+# 募集申込開始/停止
 ####################################################
 @share.route('/start_offering', methods=['POST'])
 @login_required
@@ -588,7 +588,7 @@ def _set_offering_status(token_address, status):
 
 
 ####################################################
-# [株式]有効化/無効化
+# 有効化/無効化
 ####################################################
 @share.route('/valid', methods=['POST'])
 @login_required
@@ -627,7 +627,7 @@ def _set_validity(token_address, isvalid):
 
 
 ####################################################
-# [株式]追加発行
+# 追加発行
 ####################################################
 @share.route('/add_supply/<string:token_address>', methods=['GET', 'POST'])
 @login_required
@@ -677,7 +677,7 @@ def add_supply(token_address):
 
 
 ####################################################
-# [株式]トークン追跡
+# トークン追跡
 ####################################################
 @share.route('/token/track/<string:token_address>', methods=['GET'])
 @login_required
@@ -851,7 +851,7 @@ def list_all_transfer_approvals(token_address):
 
 
 ####################################################
-# [株式]募集申込一覧
+# 募集申込一覧
 ####################################################
 # 申込一覧画面
 @share.route('/applications/<string:token_address>', methods=['GET'])
@@ -963,7 +963,7 @@ def get_applications(token_address):
 
 
 ####################################################
-# [株式]割当登録
+# 割当登録
 ####################################################
 @share.route('/allot/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required
@@ -1020,7 +1020,7 @@ def _render_allot(token_address: str, account_address: str, form: AllotForm):
 
 
 ####################################################
-# [株式]権利移転（募集申込）
+# 権利移転（募集申込）
 ####################################################
 @share.route('/transfer_allotment/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required
@@ -1089,7 +1089,7 @@ def _render_transfer_allotment(token_address: str, account_address: str, form: T
 
 
 ####################################################
-# [株式]保有者一覧
+# 保有者一覧
 ####################################################
 
 # （画面）保有者一覧
@@ -1403,7 +1403,7 @@ def get_holders(token_address):
 
 
 ####################################################
-# [株式]保有者移転
+# 保有者移転
 ####################################################
 @share.route('/transfer_ownership/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required
@@ -1464,7 +1464,7 @@ def transfer_ownership(token_address, account_address):
 
 
 ####################################################
-# [株式]保有者詳細
+# 保有者詳細
 ####################################################
 @share.route('/holder/<string:token_address>/<string:account_address>', methods=['GET', 'POST'])
 @login_required

--- a/app/templates/bond/add_supply.html
+++ b/app/templates/bond/add_supply.html
@@ -7,11 +7,11 @@
 {% set active_page = "bond_list" %}
 
 {% block title %}追加発行 - {% endblock %}
-{% block page_header %}追加発行 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}追加発行 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
+    <li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
     <li class="active">追加発行</li>
 {% endblock %}
 

--- a/app/templates/bond/allot.html
+++ b/app/templates/bond/allot.html
@@ -6,11 +6,11 @@
 {% set active_page = "bond_list" %}
 
 {% block title %}割当登録 - {% endblock %}
-{% block page_header %}割当登録 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}割当登録 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
+    <li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
     <li class="active">割当登録</li>
 {% endblock %}
 

--- a/app/templates/bond/applications.html
+++ b/app/templates/bond/applications.html
@@ -7,11 +7,11 @@
 {% set active_page = "bond_list" %}
 
 {% block title %}募集申込一覧 - {% endblock %}
-{% block page_header %}募集申込一覧 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}募集申込一覧 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
+    <li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
     <li class="active">募集申込一覧</li>
 {% endblock %}
 

--- a/app/templates/bond/bulk_transfer.html
+++ b/app/templates/bond/bulk_transfer.html
@@ -6,7 +6,7 @@
 {% set active_page = "bond_bulk_transfer" %}
 
 {% block title %}一括強制移転 - {% endblock %}
-{% block page_header %}一括強制移転 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}一括強制移転 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/bond/bulk_transfer_approval.html
+++ b/app/templates/bond/bulk_transfer_approval.html
@@ -6,7 +6,7 @@
 {% set active_page = "bond_bulk_transfer" %}
 
 {% block title %}一括強制移転承認 - {% endblock %}
-{% block page_header %}一括強制移転承認 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}一括強制移転承認 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/bond/cancel_order.html
+++ b/app/templates/bond/cancel_order.html
@@ -6,12 +6,12 @@
 {% endblock %}
 {% set active_page = "bond_position" %}
 
-{% block title %}債券売出停止 - {% endblock %}
-{% block page_header %}売出停止 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block title %}売出停止 - {% endblock %}
+{% block page_header %}売出停止 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">債券売出停止</li>
+    <li class="active">売出停止</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/bond/holder.html
+++ b/app/templates/bond/holder.html
@@ -4,13 +4,13 @@
 {% endblock %}
 {% set active_page = "bond_list" %}
 
-{% block title %}債券保有者詳細 - {% endblock %}
-{% block page_header %}債券保有者詳細 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block title %}保有者詳細 - {% endblock %}
+{% block page_header %}保有者詳細 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
-<li class="active">債券保有者詳細</li>
+<li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
+<li class="active">保有者詳細</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/bond/holders.html
+++ b/app/templates/bond/holders.html
@@ -8,13 +8,13 @@
 {% endblock %}
 {% set active_page = "bond_list" %}
 
-{% block title %}債券保有者一覧 - {% endblock %}
-{% block page_header %}債券保有者一覧 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block title %}保有者一覧 - {% endblock %}
+{% block page_header %}保有者一覧 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
-<li class="active">債券保有者一覧</li>
+<li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
+<li class="active">保有者一覧</li>
 {% endblock %}
 
 {% block page_content %}
@@ -106,12 +106,12 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td>債券名</td>
+                        <td>トークン名</td>
                         <td>ibet債券</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td>債券アドレス</td>
+                        <td>トークンアドレス</td>
                         <td>0xF37aF18966609eCaDe3E4D1831996853c637cfF3</td>
                         <td></td>
                     </tr>

--- a/app/templates/bond/holders_csv_history.html
+++ b/app/templates/bond/holders_csv_history.html
@@ -8,14 +8,14 @@
 {% endblock %}
 {% set active_page = "bond_list" %}
 
-{% block title %}債券保有者リスト履歴 - {% endblock %}
-{% block page_header %}債券保有者リスト履歴 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block title %}保有者リスト履歴 - {% endblock %}
+{% block page_header %}保有者リスト履歴 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
-<li><a href="{{ url_for('bond.holders', token_address=token_address) }}">債券保有者一覧</a></li>
-<li class="active">債券保有者リスト履歴</li>
+<li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
+<li><a href="{{ url_for('bond.holders', token_address=token_address) }}">保有者一覧</a></li>
+<li class="active">保有者リスト履歴</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/bond/issue.html
+++ b/app/templates/bond/issue.html
@@ -6,12 +6,12 @@
 {% endblock %}
 {% set active_page = "bond_issue" %}
 
-{% block title %}債券新規発行 - {% endblock %}
-{% block page_header %}債券新規発行 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block title %}新規発行 - {% endblock %}
+{% block page_header %}新規発行 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">債券新規発行</li>
+    <li class="active">新規発行</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/bond/ledger_history.html
+++ b/app/templates/bond/ledger_history.html
@@ -9,12 +9,12 @@
 {% set active_page = "bond_list" %}
 
 {% block title %}債券原簿履歴 - {% endblock %}
-{% block page_header %}債券原簿履歴 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}債券原簿履歴 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
-<li><a href="{{ url_for('bond.holders', token_address=token_address) }}">債券保有者一覧</a></li>
+<li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
+<li><a href="{{ url_for('bond.holders', token_address=token_address) }}">保有者一覧</a></li>
 <li class="active">債券原簿履歴</li>
 {% endblock %}
 

--- a/app/templates/bond/list.html
+++ b/app/templates/bond/list.html
@@ -6,19 +6,19 @@
 {% endblock %}
 {% set active_page = "bond_list" %}
 
-{% block title %}債券一覧 - {% endblock %}
-{% block page_header %}債券一覧 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block title %}発行済一覧 - {% endblock %}
+{% block page_header %}発行済一覧 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">債券一覧</li>
+    <li class="active">発行済一覧</li>
 {% endblock %}
 
 {% block page_content %}
 <section class="content">
     <div class="box box-default">
         <div class="box-header">
-            <h3 class="box-title">債券一覧</h3>
+            <h3 class="box-title">発行済トークン</h3>
         </div>
         <div class="box-body">
             <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/bond/positions.html
+++ b/app/templates/bond/positions.html
@@ -6,19 +6,19 @@
 {% endblock %}
 {% set active_page = "bond_position" %}
 
-{% block title %}債券売出管理 - {% endblock %}
-{% block page_header %}債券売出管理 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block title %}売出管理 - {% endblock %}
+{% block page_header %}売出管理 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">債券売出管理</li>
+    <li class="active">売出管理</li>
 {% endblock %}
 
 {% block page_content %}
 <section class="content">
     <div class="box box-default">
         <div class="box-header">
-            <h3 class="box-title">債券一覧</h3>
+            <h3 class="box-title">発行済一覧</h3>
         </div>
         <div class="box-body">
             <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/bond/request_signature.html
+++ b/app/templates/bond/request_signature.html
@@ -7,11 +7,11 @@
 {% set active_page = "bond_list" %}
 
 {% block title %}認定依頼 - {% endblock %}
-{% block page_header %}債券詳細設定（第三者認定依頼） <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}詳細設定（第三者認定依頼） <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li>債券詳細設定</li>
+    <li>詳細設定</li>
     <li class="active">認定依頼</li>
 {% endblock %}
 

--- a/app/templates/bond/sell.html
+++ b/app/templates/bond/sell.html
@@ -6,12 +6,12 @@
 {% endblock %}
 {% set active_page = "bond_position" %}
 
-{% block title %}債券新規売出 - {% endblock %}
-{% block page_header %}新規売出 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block title %}新規売出 - {% endblock %}
+{% block page_header %}新規売出 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">債券新規売出</li>
+    <li class="active">新規売出</li>
 {% endblock %}
 
 {% block page_content %}
@@ -43,7 +43,7 @@
     </div>
     <div class="box box-default box-solid">
         <div class="box-header with-border">
-            <h3 class="box-title">債券詳細</h3>
+            <h3 class="box-title">詳細</h3>
         </div>
         <div class="box-body">
             <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/bond/setting.html
+++ b/app/templates/bond/setting.html
@@ -6,13 +6,13 @@
 {% endblock %}
 {% set active_page = "bond_list" %}
 
-{% block title %}債券詳細設定 - {% endblock %}
-{% block page_header %}詳細設定 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block title %}詳細設定 - {% endblock %}
+{% block page_header %}詳細設定 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
-    <li class="active">債券詳細設定</li>
+    <li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
+    <li class="active">詳細設定</li>
 {% endblock %}
 
 {% block page_content %}
@@ -310,7 +310,7 @@
                     <div class="form-group">
                         <input type="text" class="form-control" autocomplete="off" id="prompt-form" name="name" />
                         <input type="text" name="dummy" style="display:none;">
-                        <p class="text-danger" id="modal-prompt-validate">名称が一致しません。償還対象の債券であることを確認してください。</p>
+                        <p class="text-danger" id="modal-prompt-validate">名称が一致しません。償還対象のトークンであることを確認してください。</p>
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -368,7 +368,7 @@
       });
       $('#redeem').click(function(){
         $('#modal-prompt-title').html('償還時確認 <i class="fa fa-exclamation-triangle"></i>');
-        $('#modal-prompt-text').html('この操作は元に戻すことができません。<br>念のため、償還を行う債券の名称を入力してください。');
+        $('#modal-prompt-text').html('この操作は元に戻すことができません。<br>念のため、償還を行うトークンの名称を入力してください。');
         $('#modal-prompt-form').attr('action', "{{ url_for('bond.redeem') }}");
         $('#modal-prompt-validate').hide();
         $('#modal-prompt').modal();

--- a/app/templates/bond/token_tracker.html
+++ b/app/templates/bond/token_tracker.html
@@ -7,11 +7,11 @@
 {% set active_page = "bond_list" %}
 
 {% block title %}トークン追跡 - {% endblock %}
-{% block page_header %}トークン追跡 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}トークン追跡 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
+    <li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
     <li class="active">追跡</li>
 {% endblock %}
 

--- a/app/templates/bond/transfer_allotment.html
+++ b/app/templates/bond/transfer_allotment.html
@@ -6,11 +6,11 @@
 {% set active_page = "bond_list" %}
 
 {% block title %}権利移転 - {% endblock %}
-{% block page_header %}権利移転（募集申込） <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}権利移転（募集申込） <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
+    <li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
     <li class="active">権利移転（募集申込）</li>
 {% endblock %}
 

--- a/app/templates/bond/transfer_ownership.html
+++ b/app/templates/bond/transfer_ownership.html
@@ -6,11 +6,11 @@
 {% set active_page = "bond_list" %}
 
 {% block title %}所有者移転 - {% endblock %}
-{% block page_header %}所有者移転 <span class="badge bg-secondary">債券</span>{% endblock %}
+{% block page_header %}所有者移転 <span class="badge bg-secondary">BOND</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('bond.list') }}">債券一覧</a></li>
+    <li><a href="{{ url_for('bond.list') }}">発行済一覧</a></li>
     <li class="active">所有者移転</li>
 {% endblock %}
 

--- a/app/templates/coupon/add_supply.html
+++ b/app/templates/coupon/add_supply.html
@@ -6,13 +6,13 @@
 {% endblock %}
 {% set active_page = "coupon_list" %}
 
-{% block title %}クーポン追加発行 - {% endblock %}
-{% block page_header %}クーポン追加発行 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block title %}追加発行 - {% endblock %}
+{% block page_header %}追加発行 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('coupon.list') }}">クーポン一覧</a></li>
-    <li class="active">クーポン追加発行</li>
+    <li><a href="{{ url_for('coupon.list') }}">発行済一覧</a></li>
+    <li class="active">追加発行</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/coupon/allocate.html
+++ b/app/templates/coupon/allocate.html
@@ -5,20 +5,20 @@
 {% endblock %}
 {% set active_page = "coupon_list" %}
 
-{% block title %}クーポン割当 - {% endblock %}
-{% block page_header %}割当（募集申込） <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block title %}割当 - {% endblock %}
+{% block page_header %}割当（募集申込） <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('coupon.list') }}">クーポン一覧</a></li>
-    <li class="active">割当</li>
+    <li><a href="{{ url_for('coupon.list') }}">発行済一覧</a></li>
+    <li class="active">トークン割当</li>
 {% endblock %}
 
 {% block page_content %}
 <section class="content">
   <div class="box box-default">
     <div class="box-header with-border">
-      <h3 class="box-title">クーポン割当</h3>
+      <h3 class="box-title">トークン割当</h3>
     </div>
     <form class="form-horizontal" method="POST" role="form" action="{{ url_for('coupon.allocate', token_address=token_address, account_address=account_address) }}">
       {{ form.csrf_token }}

--- a/app/templates/coupon/applications.html
+++ b/app/templates/coupon/applications.html
@@ -11,11 +11,11 @@
 {% set active_page = "coupon_list" %}
 
 {% block title %}募集申込一覧 - {% endblock %}
-{% block page_header %}募集申込一覧 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block page_header %}募集申込一覧 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('coupon.list') }}">クーポン一覧</a></li>
+    <li><a href="{{ url_for('coupon.list') }}">発行済一覧</a></li>
     <li class="active">募集申込一覧</li>
 {% endblock %}
 

--- a/app/templates/coupon/bulk_transfer.html
+++ b/app/templates/coupon/bulk_transfer.html
@@ -6,7 +6,7 @@
 {% set active_page = "coupon_bulk_transfer" %}
 
 {% block title %}一括強制移転 - {% endblock %}
-{% block page_header %}一括強制移転 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block page_header %}一括強制移転 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/coupon/bulk_transfer_approval.html
+++ b/app/templates/coupon/bulk_transfer_approval.html
@@ -6,7 +6,7 @@
 {% set active_page = "coupon_bulk_transfer" %}
 
 {% block title %}一括強制移転承認 - {% endblock %}
-{% block page_header %}一括強制移転承認 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block page_header %}一括強制移転承認 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/coupon/cancel_order.html
+++ b/app/templates/coupon/cancel_order.html
@@ -7,7 +7,7 @@
 {% set active_page = "coupon_position" %}
 
 {% block title %}売出停止 - {% endblock %}
-{% block page_header %}売出停止 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block page_header %}売出停止 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/coupon/holder.html
+++ b/app/templates/coupon/holder.html
@@ -5,11 +5,11 @@
 {% set active_page = "coupon_list" %}
 
 {% block title %}保有者詳細 - {% endblock %}
-{% block page_header %}保有者詳細 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block page_header %}保有者詳細 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('coupon.list') }}">クーポン一覧</a></li>
+<li><a href="{{ url_for('coupon.list') }}">発行済一覧</a></li>
 <li class="active">保有者詳細</li>
 {% endblock %}
 

--- a/app/templates/coupon/holders.html
+++ b/app/templates/coupon/holders.html
@@ -8,12 +8,12 @@
 {% endblock %}
 {% set active_page = "coupon_list" %}
 
-{% block title %}クーポン保有者一覧 - {% endblock %}
-{% block page_header %}クーポン保有者一覧 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block title %}保有者一覧 - {% endblock %}
+{% block page_header %}保有者一覧 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('coupon.list') }}">クーポン一覧</a></li>
+<li><a href="{{ url_for('coupon.list') }}">発行済一覧</a></li>
 <li class="active">保有者一覧</li>
 {% endblock %}
 
@@ -102,12 +102,12 @@
                 </thead>
                 <tbody>
                 <tr>
-                    <td>クーポン名</td>
+                    <td>トークン名</td>
                     <td>ibetクーポン</td>
                     <td></td>
                 </tr>
                 <tr>
-                    <td>クーポンアドレス</td>
+                    <td>トークンアドレス</td>
                     <td>0xF37aF18966609eCaDe3E4D1831996853c637cfF3</td>
                     <td></td>
                 </tr>

--- a/app/templates/coupon/issue.html
+++ b/app/templates/coupon/issue.html
@@ -5,19 +5,19 @@
 {% endblock %}
 {% set active_page = "coupon_issue" %}
 
-{% block title %}クーポン発行 - {% endblock %}
-{% block page_header %}クーポン発行 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block title %}新規発行 - {% endblock %}
+{% block page_header %}新規発行 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">クーポン発行</li>
+    <li class="active">新規発行</li>
 {% endblock %}
 
 {% block page_content %}
 <section class="content">
     <div class="box box-default">
         <div class="box-header with-border">
-            <h3 class="box-title">クーポン発行</h3>
+            <h3 class="box-title">新規発行</h3>
         </div>
         <form class="form-horizontal" method="POST" role="form" action="{{ url_for('coupon.issue') }}">
             {{ form.csrf_token }}

--- a/app/templates/coupon/list.html
+++ b/app/templates/coupon/list.html
@@ -6,19 +6,19 @@
 {% endblock %}
 {% set active_page = "coupon_list" %}
 
-{% block title %}クーポン一覧 - {% endblock %}
-{% block page_header %}クーポン一覧 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block title %}発行済一覧 - {% endblock %}
+{% block page_header %}発行済一覧 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">クーポン一覧</li>
+    <li class="active">発行済一覧</li>
 {% endblock %}
 
 {% block page_content %}
 <section class="content">
   <div class="box box-default">
     <div class="box-header">
-      <h3 class="box-title">クーポン一覧</h3>
+      <h3 class="box-title">発行済トークン</h3>
     </div>
     <div class="box-body">
   	  <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/coupon/positions.html
+++ b/app/templates/coupon/positions.html
@@ -7,7 +7,7 @@
 {% set active_page = "coupon_position" %}
 
 {% block title %}売出管理 - {% endblock %}
-{% block page_header %}売出管理 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block page_header %}売出管理 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
@@ -18,7 +18,7 @@
 <section class="content">
     <div class="box box-default">
         <div class="box-header">
-            <h3 class="box-title">クーポン一覧</h3>
+            <h3 class="box-title">発行済一覧</h3>
         </div>
         <div class="box-body">
             <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/coupon/sell.html
+++ b/app/templates/coupon/sell.html
@@ -7,7 +7,7 @@
 {% set active_page = "coupon_position" %}
 
 {% block title %}新規売出 - {% endblock %}
-{% block page_header %}新規売出 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block page_header %}新規売出 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
@@ -43,7 +43,7 @@
     </div>
     <div class="box box-default box-solid">
         <div class="box-header with-border">
-            <h3 class="box-title">クーポン詳細</h3>
+            <h3 class="box-title">詳細</h3>
         </div>
         <div class="box-body">
             <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/coupon/setting.html
+++ b/app/templates/coupon/setting.html
@@ -6,13 +6,13 @@
 {% endblock %}
 {% set active_page = "coupon_list" %}
 
-{% block title %}クーポン詳細設定 - {% endblock %}
-{% block page_header %}詳細設定 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block title %}詳細設定 - {% endblock %}
+{% block page_header %}詳細設定 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('coupon.list') }}">クーポン一覧</a></li>
-    <li class="active">クーポン詳細設定</li>
+    <li><a href="{{ url_for('coupon.list') }}">発行済一覧</a></li>
+    <li class="active">詳細設定</li>
 {% endblock %}
 
 {% block page_content %}
@@ -62,7 +62,7 @@
                       type="button" class="btn btn-danger btn-sm"
                       data-loading-text="<i class='fa fa-spinner fa-spin '></i> 処理中"
                       style="width: 120px">
-                      クーポン無効化 <i class="fa fa-exclamation-triangle"></i>
+                      無効化 <i class="fa fa-exclamation-triangle"></i>
                     </button>
                 {% else %}
                     <button
@@ -70,7 +70,7 @@
                       type="button" class="btn btn-success btn-sm"
                       data-loading-text="<i class='fa fa-spinner fa-spin '></i> 処理中"
                       style="width: 120px">
-                      クーポン有効化
+                      有効化
                     </button>
                 {% endif %}
             </div>
@@ -251,17 +251,17 @@
         }, 10000);
       });
       $('#release').click(function(){
-        $("#modal-text").html("このクーポンをウォレット向けに公開します。よろしいですか？");
+        $("#modal-text").html("このトークンをウォレット向けに公開します。よろしいですか？");
         $('#modal-form').attr('action', "{{ url_for('coupon.release') }}");
         $('#modal-confirm').modal();
       });
       $('#invalid').click(function(){
-        $("#modal-text").html("このクーポンを無効化します。よろしいですか？");
+        $("#modal-text").html("このトークンを無効化します。よろしいですか？");
         $('#modal-form').attr('action', "{{ url_for('coupon.invalid') }}");
         $('#modal-confirm').modal();
       });
       $('#valid').click(function(){
-        $("#modal-text").html("このクーポンを有効化します。よろしいですか？");
+        $("#modal-text").html("このトークンを有効化します。よろしいですか？");
         $('#modal-form').attr('action', "{{ url_for('coupon.valid') }}");
         $('#modal-confirm').modal();
       });

--- a/app/templates/coupon/token_tracker.html
+++ b/app/templates/coupon/token_tracker.html
@@ -7,11 +7,11 @@
 {% set active_page = "coupon_list" %}
 
 {% block title %}トークン追跡 - {% endblock %}
-{% block page_header %}トークン追跡 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block page_header %}トークン追跡 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('coupon.list') }}">クーポン一覧</a></li>
+    <li><a href="{{ url_for('coupon.list') }}">発行済一覧</a></li>
     <li class="active">追跡</li>
 {% endblock %}
 

--- a/app/templates/coupon/transfer.html
+++ b/app/templates/coupon/transfer.html
@@ -5,19 +5,19 @@
 {% endblock %}
 {% set active_page = "coupon_transfer" %}
 
-{% block title %}クーポン割当 - {% endblock %}
-{% block page_header %}クーポン割当 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block title %}トークン割当 - {% endblock %}
+{% block page_header %}トークン割当 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">クーポン割当</li>
+    <li class="active">トークン割当</li>
 {% endblock %}
 
 {% block page_content %}
 <section class="content">
     <div class="box box-default">
         <div class="box-header with-border">
-            <h3 class="box-title">クーポン割当</h3>
+            <h3 class="box-title">トークン割当</h3>
         </div>
         <form class="form-horizontal" method="POST" role="form" action="{{ url_for('coupon.transfer') }}">
             {{ form.csrf_token }}
@@ -25,7 +25,7 @@
                 <p class="help-block">
                     <small>
                         <i class="fa fa-info-circle" aria-hidden="true"></i>
-                        割当を行うクーポンの情報を入力してください。
+                        割当を行うトークンの情報を入力してください。
                     </small>
                 </p>
                 <div class="form-group">

--- a/app/templates/coupon/transfer_ownership.html
+++ b/app/templates/coupon/transfer_ownership.html
@@ -6,11 +6,11 @@
 {% set active_page = "coupon_list" %}
 
 {% block title %}所有者移転 - {% endblock %}
-{% block page_header %}所有者移転 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block page_header %}所有者移転 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('coupon.list') }}">クーポン一覧</a></li>
+    <li><a href="{{ url_for('coupon.list') }}">発行済一覧</a></li>
     <li class="active">所有者移転</li>
 {% endblock %}
 

--- a/app/templates/coupon/usage_history.html
+++ b/app/templates/coupon/usage_history.html
@@ -8,13 +8,13 @@
 {% endblock %}
 {% set active_page = "coupon_list" %}
 
-{% block title %}クーポン利用履歴 - {% endblock %}
-{% block page_header %}クーポン利用履歴 <span class="badge bg-secondary">クーポン</span>{% endblock %}
+{% block title %}利用履歴 - {% endblock %}
+{% block page_header %}利用履歴 <span class="badge bg-secondary">COUPON</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('coupon.list') }}">クーポン一覧</a></li>
-    <li class="active">クーポン利用履歴</li>
+    <li><a href="{{ url_for('coupon.list') }}">発行済一覧</a></li>
+    <li class="active">利用履歴</li>
 {% endblock %}
 
 {% block page_content %}
@@ -97,12 +97,12 @@
                 </thead>
                 <tbody>
                 <tr>
-                    <td>クーポン名</td>
+                    <td>トークン名</td>
                     <td>ibetクーポン</td>
                     <td></td>
                 </tr>
                 <tr>
-                    <td>クーポンアドレス</td>
+                    <td>トークンアドレス</td>
                     <td>0xF37aF18966609eCaDe3E4D1831996853c637cfF3</td>
                     <td></td>
                 </tr>

--- a/app/templates/dashboard/main.html
+++ b/app/templates/dashboard/main.html
@@ -20,7 +20,7 @@
             <div class="col-12">
                 <div class="box box-solid box-success">
                     <div class="box-header with-border">
-                        <h3 class="box-title">株式</h3>
+                        <h3 class="box-title">SHARE</h3>
                         <div class="box-tools pull-right">
                             <button type="button" class="btn btn-box-tool" data-widget="collapse">
                                 <i class="fa fa-minus"></i>
@@ -52,7 +52,7 @@
             <div class="col-12">
                 <div class="box box-solid box-success">
                     <div class="box-header with-border">
-                        <h3 class="box-title">債券</h3>
+                        <h3 class="box-title">BOND</h3>
                         <div class="box-tools pull-right">
                             <button type="button" class="btn btn-box-tool" data-widget="collapse">
                                 <i class="fa fa-minus"></i>
@@ -83,7 +83,7 @@
             <div class="col-12">
                 <div class="box box-solid box-success">
                     <div class="box-header with-border">
-                        <h3 class="box-title">会員権</h3>
+                        <h3 class="box-title">MEMBERSHIP</h3>
                         <div class="box-tools pull-right">
                             <button type="button" class="btn btn-box-tool" data-widget="collapse">
                                 <i class="fa fa-minus"></i>
@@ -112,7 +112,7 @@
             <div class="col-12">
                 <div class="box box-solid box-success">
                     <div class="box-header with-border">
-                        <h3 class="box-title">クーポン</h3>
+                        <h3 class="box-title">COUPON</h3>
                         <div class="box-tools pull-right">
                             <button type="button" class="btn btn-box-tool" data-widget="collapse">
                                 <i class="fa fa-minus"></i>

--- a/app/templates/membership/add_supply.html
+++ b/app/templates/membership/add_supply.html
@@ -7,12 +7,12 @@
 {% set active_page = "membership_list" %}
 
 {% block title %}追加発行 - {% endblock %}
-{% block page_header %}追加発行 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}追加発行 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('membership.list') }}">会員権一覧</a></li>
-    <li class="active">会員権追加発行</li>
+    <li><a href="{{ url_for('membership.list') }}">発行済一覧</a></li>
+    <li class="active">追加発行</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/membership/allocate.html
+++ b/app/templates/membership/allocate.html
@@ -5,20 +5,20 @@
 {% endblock %}
 {% set active_page = "membership_list" %}
 
-{% block title %}会員権割当 - {% endblock %}
-{% block page_header %}割当（募集申込） <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block title %}トークン割当 - {% endblock %}
+{% block page_header %}割当（募集申込） <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('membership.list') }}">会員権一覧</a></li>
-    <li class="active">割当</li>
+    <li><a href="{{ url_for('membership.list') }}">発行済一覧</a></li>
+    <li class="active">トークン割当</li>
 {% endblock %}
 
 {% block page_content %}
 <section class="content">
   <div class="box box-default">
     <div class="box-header with-border">
-      <h3 class="box-title">会員権割当</h3>
+      <h3 class="box-title">トークン割当</h3>
     </div>
     <form class="form-horizontal" method="POST" role="form" action="{{ url_for('membership.allocate', token_address=token_address, account_address=account_address) }}">
       {{ form.csrf_token }}

--- a/app/templates/membership/applications.html
+++ b/app/templates/membership/applications.html
@@ -7,11 +7,11 @@
 {% set active_page = "membership_list" %}
 
 {% block title %}募集申込一覧 - {% endblock %}
-{% block page_header %}募集申込一覧 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}募集申込一覧 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('membership.list') }}">会員権一覧</a></li>
+    <li><a href="{{ url_for('membership.list') }}">発行済一覧</a></li>
     <li class="active">募集申込一覧</li>
 {% endblock %}
 

--- a/app/templates/membership/bulk_transfer.html
+++ b/app/templates/membership/bulk_transfer.html
@@ -6,7 +6,7 @@
 {% set active_page = "membership_bulk_transfer" %}
 
 {% block title %}一括強制移転 - {% endblock %}
-{% block page_header %}一括強制移転 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}一括強制移転 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/membership/bulk_transfer_approval.html
+++ b/app/templates/membership/bulk_transfer_approval.html
@@ -6,7 +6,7 @@
 {% set active_page = "membership_bulk_transfer" %}
 
 {% block title %}一括強制移転承認 - {% endblock %}
-{% block page_header %}一括強制移転承認 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}一括強制移転承認 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/membership/cancel_order.html
+++ b/app/templates/membership/cancel_order.html
@@ -7,7 +7,7 @@
 {% set active_page = "membership_position" %}
 
 {% block title %}売出停止 - {% endblock %}
-{% block page_header %}売出停止 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}売出停止 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/membership/holder.html
+++ b/app/templates/membership/holder.html
@@ -5,11 +5,11 @@
 {% set active_page = "membership_list" %}
 
 {% block title %}保有者詳細 - {% endblock %}
-{% block page_header %}保有者詳細 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}保有者詳細 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('membership.list') }}">会員権一覧</a></li>
+<li><a href="{{ url_for('membership.list') }}">発行済一覧</a></li>
 <li><a href="{{ url_for("membership.holders", token_address=token_address) }}">保有者一覧</a></li>
 <li class="active">保有者詳細</li>
 {% endblock %}

--- a/app/templates/membership/holders.html
+++ b/app/templates/membership/holders.html
@@ -9,11 +9,11 @@
 {% set active_page = "membership_list" %}
 
 {% block title %}保有者一覧 - {% endblock %}
-{% block page_header %}保有者一覧 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}保有者一覧 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('membership.list') }}">会員権一覧</a></li>
+<li><a href="{{ url_for('membership.list') }}">発行済一覧</a></li>
 <li class="active">保有者一覧</li>
 {% endblock %}
 
@@ -105,12 +105,12 @@
                 </thead>
                 <tbody>
                 <tr>
-                    <td>会員権名</td>
+                    <td>トークン名</td>
                     <td>ibet会員権</td>
                     <td></td>
                 </tr>
                 <tr>
-                    <td>会員権アドレス</td>
+                    <td>トークンアドレス</td>
                     <td>0xF37aF18966609eCaDe3E4D1831996853c637cfF3</td>
                     <td></td>
                 </tr>

--- a/app/templates/membership/holders_csv_history.html
+++ b/app/templates/membership/holders_csv_history.html
@@ -9,11 +9,11 @@
 {% set active_page = "membership_list" %}
 
 {% block title %}保有者リスト履歴 - {% endblock %}
-{% block page_header %}保有者リスト履歴 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}保有者リスト履歴 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('membership.list') }}">会員権一覧</a></li>
+    <li><a href="{{ url_for('membership.list') }}">発行済一覧</a></li>
     <li><a href="{{ url_for('membership.holders', token_address=token_address) }}">保有者一覧</a></li>
     <li class="active">保有者リスト履歴</li>
 {% endblock %}

--- a/app/templates/membership/issue.html
+++ b/app/templates/membership/issue.html
@@ -3,12 +3,12 @@
 <link rel="stylesheet" href="/static/adminlte/bower_components/datatables.net-bs/css/dataTables.bootstrap.min.css">
 {% endblock %}
 {% set active_page = "membership_issue" %}
-{% block title %}会員権新規発行 - {% endblock %}
-{% block page_header %}会員権新規発行 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block title %}新規発行 - {% endblock %}
+{% block page_header %}新規発行 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li class="active">会員権新規発行</li>
+<li class="active">新規発行</li>
 {% endblock %} {% block page_content %}
 <section class="content">
     <div class="box box-default">

--- a/app/templates/membership/list.html
+++ b/app/templates/membership/list.html
@@ -6,19 +6,19 @@
 {% endblock %}
 {% set active_page = "membership_list" %}
 
-{% block title %}会員権一覧 - {% endblock %}
-{% block page_header %}会員権一覧 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block title %}発行済一覧 - {% endblock %}
+{% block page_header %}発行済一覧 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">会員権一覧</li>
+    <li class="active">発行済一覧</li>
 {% endblock %}
 
 {% block page_content %}
 <section class="content">
     <div class="box box-default">
         <div class="box-header">
-            <h3 class="box-title">会員権一覧</h3>
+            <h3 class="box-title">発行済トークン</h3>
         </div>
         <div class="box-body">
             <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/membership/positions.html
+++ b/app/templates/membership/positions.html
@@ -7,7 +7,7 @@
 {% set active_page = "membership_position" %}
 
 {% block title %}売出管理 - {% endblock %}
-{% block page_header %}売出管理 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}売出管理 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
@@ -18,7 +18,7 @@
 <section class="content">
     <div class="box box-default">
         <div class="box-header">
-            <h3 class="box-title">会員権一覧</h3>
+            <h3 class="box-title">発行済一覧</h3>
         </div>
         <div class="box-body">
             <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/membership/sell.html
+++ b/app/templates/membership/sell.html
@@ -7,7 +7,7 @@
 {% set active_page = "membership_position" %}
 
 {% block title %}新規売出 - {% endblock %}
-{% block page_header %}新規売出 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}新規売出 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
@@ -43,7 +43,7 @@
     </div>
     <div class="box box-default box-solid">
         <div class="box-header with-border">
-            <h3 class="box-title">会員権詳細</h3>
+            <h3 class="box-title">詳細</h3>
         </div>
         <div class="box-body">
             <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/membership/setting.html
+++ b/app/templates/membership/setting.html
@@ -6,13 +6,13 @@
 {% endblock %}
 {% set active_page = "membership_list" %}
 
-{% block title %}会員権詳細設定 - {% endblock %}
-{% block page_header %}詳細設定 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block title %}詳細設定 - {% endblock %}
+{% block page_header %}詳細設定 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('membership.list') }}">会員権一覧</a></li>
-    <li class="active">会員権詳細設定</li>
+    <li><a href="{{ url_for('membership.list') }}">発行済一覧</a></li>
+    <li class="active">詳細設定</li>
 {% endblock %}
 
 {% block page_content %}
@@ -247,7 +247,7 @@
           }, 10000);
         });
       $('#release').click(function(){
-        $("#modal-text").html("この会員権をウォレット向けに公開します。よろしいですか？");
+        $("#modal-text").html("このトークンをウォレット向けに公開します。よろしいですか？");
         $('#modal-form').attr('action', "{{ url_for('membership.release') }}");
         $('#modal-confirm').modal();
       });

--- a/app/templates/membership/token_tracker.html
+++ b/app/templates/membership/token_tracker.html
@@ -7,11 +7,11 @@
 {% set active_page = "membership_list" %}
 
 {% block title %}トークン追跡 - {% endblock %}
-{% block page_header %}トークン追跡 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}トークン追跡 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('membership.list') }}">会員権一覧</a></li>
+    <li><a href="{{ url_for('membership.list') }}">発行済一覧</a></li>
     <li class="active">追跡</li>
 {% endblock %}
 

--- a/app/templates/membership/transfer_ownership.html
+++ b/app/templates/membership/transfer_ownership.html
@@ -6,11 +6,11 @@
 {% set active_page = "membership_list" %}
 
 {% block title %}所有者移転 - {% endblock %}
-{% block page_header %}所有者移転 <span class="badge bg-secondary">会員権</span>{% endblock %}
+{% block page_header %}所有者移転 <span class="badge bg-secondary">MEMBERSHIP</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('membership.list') }}">会員権一覧</a></li>
+    <li><a href="{{ url_for('membership.list') }}">発行済一覧</a></li>
     <li class="active">所有者移転</li>
 {% endblock %}
 

--- a/app/templates/share/add_supply.html
+++ b/app/templates/share/add_supply.html
@@ -7,12 +7,12 @@
 {% set active_page = "share_list" %}
 
 {% block title %}追加発行 - {% endblock %}
-{% block page_header %}追加発行 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block page_header %}追加発行 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
-    <li class="active">株式追加発行</li>
+    <li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
+    <li class="active">追加発行</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/share/allot.html
+++ b/app/templates/share/allot.html
@@ -6,11 +6,11 @@
 {% set active_page = "share_list" %}
 
 {% block title %}割当登録 - {% endblock %}
-{% block page_header %}割当登録 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block page_header %}割当登録 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
+    <li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
     <li class="active">割当登録</li>
 {% endblock %}
 

--- a/app/templates/share/applications.html
+++ b/app/templates/share/applications.html
@@ -7,11 +7,11 @@
 {% set active_page = "share_list" %}
 
 {% block title %}募集申込一覧 - {% endblock %}
-{% block page_header %}募集申込一覧 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block page_header %}募集申込一覧 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
+    <li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
     <li class="active">募集申込一覧</li>
 {% endblock %}
 

--- a/app/templates/share/bulk_transfer.html
+++ b/app/templates/share/bulk_transfer.html
@@ -6,7 +6,7 @@
 {% set active_page = "share_bulk_transfer" %}
 
 {% block title %}一括強制移転 - {% endblock %}
-{% block page_header %}一括強制移転 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block page_header %}一括強制移転 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/share/bulk_transfer_approval.html
+++ b/app/templates/share/bulk_transfer_approval.html
@@ -6,7 +6,7 @@
 {% set active_page = "share_bulk_transfer" %}
 
 {% block title %}一括強制移転承認 - {% endblock %}
-{% block page_header %}一括強制移転承認 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block page_header %}一括強制移転承認 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>

--- a/app/templates/share/holder.html
+++ b/app/templates/share/holder.html
@@ -4,13 +4,13 @@
 {% endblock %}
 {% set active_page = "share_list" %}
 
-{% block title %}株式保有者詳細 - {% endblock %}
-{% block page_header %}株式保有者詳細 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block title %}保有者詳細 - {% endblock %}
+{% block page_header %}保有者詳細 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
-<li class="active">株式保有者詳細</li>
+<li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
+<li class="active">保有者詳細</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/share/holders.html
+++ b/app/templates/share/holders.html
@@ -8,13 +8,13 @@
 {% endblock %}
 {% set active_page = "share_list" %}
 
-{% block title %}株式保有者一覧 - {% endblock %}
-{% block page_header %}株式保有者一覧 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block title %}保有者一覧 - {% endblock %}
+{% block page_header %}保有者一覧 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
-<li class="active">株式保有者一覧</li>
+<li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
+<li class="active">保有者一覧</li>
 {% endblock %}
 
 {% block page_content %}
@@ -104,12 +104,12 @@
                 </thead>
                 <tbody>
                 <tr>
-                    <td>株式名</td>
+                    <td>トークン名</td>
                     <td>ibet株</td>
                     <td></td>
                 </tr>
                 <tr>
-                    <td>株式アドレス</td>
+                    <td>トークンアドレス</td>
                     <td>0xF37aF18966609eCaDe3E4D1831996853c637cfF3</td>
                     <td></td>
                 </tr>

--- a/app/templates/share/holders_csv_history.html
+++ b/app/templates/share/holders_csv_history.html
@@ -8,14 +8,14 @@
 {% endblock %}
 {% set active_page = "share_list" %}
 
-{% block title %}株式保有者リスト履歴 - {% endblock %}
-{% block page_header %}株式保有者リスト履歴 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block title %}保有者リスト履歴 - {% endblock %}
+{% block page_header %}保有者リスト履歴 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
-    <li><a href="{{ url_for('share.holders', token_address=token_address) }}">株式保有者一覧</a></li>
-    <li class="active">株式保有者リスト履歴</li>
+    <li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
+    <li><a href="{{ url_for('share.holders', token_address=token_address) }}">保有者一覧</a></li>
+    <li class="active">保有者リスト履歴</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/share/issue.html
+++ b/app/templates/share/issue.html
@@ -6,12 +6,12 @@
 {% endblock %}
 {% set active_page = "share_issue" %}
 
-{% block title %}株式新規発行 - {% endblock %}
-{% block page_header %}株式新規発行 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block title %}新規発行 - {% endblock %}
+{% block page_header %}新規発行 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">株式新規発行</li>
+    <li class="active">新規発行</li>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/share/list.html
+++ b/app/templates/share/list.html
@@ -6,19 +6,19 @@
 {% endblock %}
 {% set active_page = "share_list" %}
 
-{% block title %}株式一覧 - {% endblock %}
-{% block page_header %}株式一覧 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block title %}発行済一覧 - {% endblock %}
+{% block page_header %}発行済一覧 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li class="active">株式一覧</li>
+    <li class="active">発行済一覧</li>
 {% endblock %}
 
 {% block page_content %}
 <section class="content">
     <div class="box box-default">
         <div class="box-header">
-            <h3 class="box-title">株式一覧</h3>
+            <h3 class="box-title">発行済トークン</h3>
         </div>
         <div class="box-body">
             <table id="data_table" class="table table-bordered table-hover">

--- a/app/templates/share/setting.html
+++ b/app/templates/share/setting.html
@@ -6,13 +6,13 @@
 {% endblock %}
 {% set active_page = "share_list" %}
 
-{% block title %}株式詳細設定 - {% endblock %}
-{% block page_header %}詳細設定 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block title %}詳細設定 - {% endblock %}
+{% block page_header %}詳細設定 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
-    <li class="active">株式詳細設定</li>
+    <li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
+    <li class="active">詳細設定</li>
 {% endblock %}
 
 {% block page_content %}
@@ -276,7 +276,7 @@
                     <div class="form-group">
                         <input type="text" class="form-control" autocomplete="off" id="prompt-form" name="name" />
                         <input type="text" name="dummy" style="display:none;">
-                        <p class="text-danger" id="modal-prompt-validate">名称が一致しません。償還対象の株式であることを確認してください。</p>
+                        <p class="text-danger" id="modal-prompt-validate">名称が一致しません。償還対象のトークンであることを確認してください。</p>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/app/templates/share/token_tracker.html
+++ b/app/templates/share/token_tracker.html
@@ -7,11 +7,11 @@
 {% set active_page = "share_list" %}
 
 {% block title %}トークン追跡 - {% endblock %}
-{% block page_header %}トークン追跡 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block page_header %}トークン追跡 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
+    <li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
     <li class="active">追跡</li>
 {% endblock %}
 

--- a/app/templates/share/transfer_allotment.html
+++ b/app/templates/share/transfer_allotment.html
@@ -6,11 +6,11 @@
 {% set active_page = "share_list" %}
 
 {% block title %}権利移転 - {% endblock %}
-{% block page_header %}権利移転（募集申込） <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block page_header %}権利移転（募集申込） <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
+    <li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
     <li class="active">権利移転（募集申込）</li>
 {% endblock %}
 

--- a/app/templates/share/transfer_approvals.html
+++ b/app/templates/share/transfer_approvals.html
@@ -7,11 +7,11 @@
 {% set active_page = "share_list" %}
 
 {% block title %}移転承諾履歴 - {% endblock %}
-{% block page_header %}移転承諾履歴 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block page_header %}移転承諾履歴 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-<li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
+<li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
 <li class="active">移転承諾履歴</li>
 {% endblock %}
 

--- a/app/templates/share/transfer_ownership.html
+++ b/app/templates/share/transfer_ownership.html
@@ -6,11 +6,11 @@
 {% set active_page = "share_list" %}
 
 {% block title %}所有者移転 - {% endblock %}
-{% block page_header %}所有者移転 <span class="badge bg-secondary">株式</span>{% endblock %}
+{% block page_header %}所有者移転 <span class="badge bg-secondary">SHARE</span>{% endblock %}
 {% block page_description %}{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ url_for('index.index') }}">トップ</a></li>
-    <li><a href="{{ url_for('share.list') }}">株式一覧</a></li>
+    <li><a href="{{ url_for('share.list') }}">発行済一覧</a></li>
     <li class="active">所有者移転</li>
 {% endblock %}
 

--- a/app/tests/script/INSERT_coupon_consume.py
+++ b/app/tests/script/INSERT_coupon_consume.py
@@ -236,7 +236,7 @@ def main(data_count, issuer):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="クーポン利用履歴の登録")
+    parser = argparse.ArgumentParser(description="利用履歴の登録")
     parser.add_argument("data_count", type=int, help="登録件数")
     parser.add_argument("--issuer", '-s', type=str, help="発行体アドレス")
     args = parser.parse_args()

--- a/app/tests/test_bond.py
+++ b/app/tests/test_bond.py
@@ -143,22 +143,22 @@ class TestBond(TestBase):
         )
 
     # ＜正常系1＞
-    #   債券一覧の参照(0件)
+    #   発行済一覧の参照(0件)
     def test_normal_1(self, app):
-        # 債券一覧
+        # 発行済一覧
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>債券一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert 'データが存在しません'.encode('utf-8') in response.data
 
     # ＜正常系2＞
-    #   債券売出管理(0件)
+    #   売出管理(0件)
     def test_normal_2(self, app):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_positions)
         assert response.status_code == 200
-        assert '<title>債券売出管理'.encode('utf-8') in response.data
+        assert '<title>売出管理'.encode('utf-8') in response.data
         assert 'データが存在しません'.encode('utf-8') in response.data
 
     # ＜正常系3＞
@@ -206,7 +206,7 @@ class TestBond(TestBase):
         token = tokens[0]
         response = client.get(self.url_setting + token.token_address)
         assert response.status_code == 200
-        assert '<title>債券詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert 'テスト債券'.encode('utf-8') in response.data
         assert 'BOND'.encode('utf-8') in response.data
         assert '1000000'.encode('utf-8') in response.data
@@ -233,12 +233,12 @@ class TestBond(TestBase):
         assert 'メモ'.encode('utf-8') in response.data
 
     # ＜正常系4＞
-    #   債券一覧の参照(1件)
+    #   発行済一覧の参照(1件)
     def test_normal_4(self, app):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>債券一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert 'テスト債券'.encode('utf-8') in response.data
         assert 'BOND'.encode('utf-8') in response.data
 
@@ -248,7 +248,7 @@ class TestBond(TestBase):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_positions)
         assert response.status_code == 200
-        assert '<title>債券売出管理'.encode('utf-8') in response.data
+        assert '<title>売出管理'.encode('utf-8') in response.data
         assert 'テスト債券'.encode('utf-8') in response.data
 
     # ＜正常系6＞
@@ -259,7 +259,7 @@ class TestBond(TestBase):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_sell + token.token_address)
         assert response.status_code == 200
-        assert '<title>債券新規売出'.encode('utf-8') in response.data
+        assert '<title>新規売出'.encode('utf-8') in response.data
         assert 'テスト債券'.encode('utf-8') in response.data
         assert 'BOND'.encode('utf-8') in response.data
         assert "{:,}".format(1000000).encode('utf-8') in response.data
@@ -284,7 +284,7 @@ class TestBond(TestBase):
         assert shared_contract['IbetStraightBondExchange']['address'].encode('utf-8') in response.data
 
     # ＜正常系7＞
-    #   売出 → 債券売出管理で確認
+    #   売出 → 売出管理で確認
     def test_normal_7(self, app):
         client = self.client_with_admin_login(app)
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_SB).all()
@@ -300,15 +300,15 @@ class TestBond(TestBase):
         )
         assert response.status_code == 302
 
-        # 債券売出管理を参照
+        # 売出管理を参照
         response = client.get(self.url_positions)
         assert response.status_code == 200
-        assert '<title>債券売出管理'.encode('utf-8') in response.data
+        assert '<title>売出管理'.encode('utf-8') in response.data
         assert '新規売出を受け付けました。売出開始までに数分程かかることがあります。'.encode('utf-8') in response.data
         assert 'テスト債券'.encode('utf-8') in response.data
 
     # ＜正常系8＞
-    #   売出停止 → 債券売出管理で確認
+    #   売出停止 → 売出管理で確認
     def test_normal_8(self, app):
         client = self.client_with_admin_login(app)
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_SB).all()
@@ -320,10 +320,10 @@ class TestBond(TestBase):
         )
         assert response.status_code == 302
 
-        # 債券売出管理を参照
+        # 売出管理を参照
         response = client.get(self.url_positions)
         assert response.status_code == 200
-        assert '<title>債券売出管理'.encode('utf-8') in response.data
+        assert '<title>売出管理'.encode('utf-8') in response.data
         assert 'テスト債券'.encode('utf-8') in response.data
 
     # ＜正常系9＞
@@ -366,7 +366,7 @@ class TestBond(TestBase):
         # 詳細設定画面を参照
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>債券詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert 'テスト債券'.encode('utf-8') in response.data
         assert '1.243'.encode('utf-8') in response.data
         # interestPaymentDateの確認
@@ -423,15 +423,15 @@ class TestBond(TestBase):
         )
         assert response.status_code == 302
 
-        # 債券詳細設定
+        # 詳細設定
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>債券詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '公開中です。公開開始までに数分程かかることがあります。'.encode('utf-8') in response.data
 
     # ＜正常系11-1＞
-    #   債券保有者一覧
+    #   保有者一覧
     def test_normal_11_1(self, app):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_SB).all()
         token = tokens[0]
@@ -440,11 +440,11 @@ class TestBond(TestBase):
         # 保有者一覧の参照
         response = client.get(self.url_holders + token.token_address)
         assert response.status_code == 200
-        assert '<title>債券保有者一覧'.encode('utf-8') in response.data
+        assert '<title>保有者一覧'.encode('utf-8') in response.data
         assert token.token_address.encode('utf-8') in response.data
 
     # ＜正常系11-2＞
-    #   債券保有者一覧(API)
+    #   保有者一覧(API)
     def test_normal_11_2(self, app):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_SB).all()
         token = tokens[0]
@@ -502,7 +502,7 @@ class TestBond(TestBase):
         assert response_csv == assumed_csv
 
     # ＜正常系12＞
-    #   債券保有者詳細
+    #   保有者詳細
     def test_normal_12(self, app):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_SB).all()
         token = tokens[0]
@@ -511,7 +511,7 @@ class TestBond(TestBase):
         # 保有者詳細の参照
         response = client.get(self.url_holder + token.token_address + '/' + eth_account['issuer']['account_address'])
         assert response.status_code == 200
-        assert '<title>債券保有者詳細'.encode('utf-8') in response.data
+        assert '<title>保有者詳細'.encode('utf-8') in response.data
         assert eth_account['issuer']['account_address'].encode('utf-8') in response.data
         assert '1234567'.encode('utf-8') in response.data
         assert '東京都'.encode('utf-8') in response.data
@@ -542,10 +542,10 @@ class TestBond(TestBase):
         )
         assert response.status_code == 302
 
-        # 債券詳細設定画面を参照
+        # 詳細設定画面を参照
         response = client.get(self.url_setting + token.token_address)
         assert response.status_code == 200
-        assert '<title>債券詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '認定依頼を受け付けました。'.encode('utf-8') in response.data
 
     # ＜正常系14_1＞
@@ -560,7 +560,7 @@ class TestBond(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>債券詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込開始'.encode('utf-8') in response.data
 
     # ＜正常系14_2＞
@@ -584,7 +584,7 @@ class TestBond(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>債券詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込停止'.encode('utf-8') in response.data
 
     # ＜正常系14_3＞
@@ -608,7 +608,7 @@ class TestBond(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>債券詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込開始'.encode('utf-8') in response.data
 
         # 募集申込状態に戻す
@@ -660,7 +660,7 @@ class TestBond(TestBase):
         assert trader_address.encode('utf-8') in applications.data
 
     # ＜正常系16＞
-    #   償還実施　→　債券一覧で確認
+    #   償還実施　→　発行済一覧で確認
     def test_normal_16(self, app):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_SB).all()
         token = tokens[0]
@@ -673,11 +673,11 @@ class TestBond(TestBase):
         )
         assert response.status_code == 302
 
-        # 債券一覧を参照
+        # 発行済一覧を参照
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>債券一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert 'テスト債券'.encode('utf-8') in response.data
         assert 'BOND'.encode('utf-8') in response.data
         assert '償還済'.encode('utf-8') in response.data
@@ -763,7 +763,7 @@ class TestBond(TestBase):
         assert 'テスト債券' == response_data
 
     # ＜正常系18-1＞
-    #   債券保有者リスト履歴
+    #   保有者リスト履歴
     def test_normal_18_1(self, app):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_SB).all()
         token = tokens[0]
@@ -772,11 +772,11 @@ class TestBond(TestBase):
         # 保有者一覧の参照
         response = client.get(self.url_holders_csv_history + token.token_address)
         assert response.status_code == 200
-        assert '<title>債券保有者リスト履歴'.encode('utf-8') in response.data
+        assert '<title>保有者リスト履歴'.encode('utf-8') in response.data
         assert token.token_address.encode('utf-8') in response.data
 
     # ＜正常系18-2＞
-    #   債券保有者リスト履歴（API）
+    #   保有者リスト履歴（API）
     #   0件：保有者リスト履歴
     def test_normal_18_2(self, app):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_SB).all()
@@ -791,7 +791,7 @@ class TestBond(TestBase):
         assert len(response_data) == 0
 
     # ＜正常系18-3＞
-    #   債券保有者リスト履歴（API）
+    #   保有者リスト履歴（API）
     #   1件：保有者リスト履歴
     def test_normal_18_3(self, app, db):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_SB).all()
@@ -922,7 +922,7 @@ class TestBond(TestBase):
     #############################################################################
 
     # ＜エラー系1＞
-    #   債券新規発行（必須エラー）
+    #   新規発行（必須エラー）
     def test_error_1(self, app):
         client = self.client_with_admin_login(app)
         # 新規発行
@@ -932,7 +932,7 @@ class TestBond(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>債券新規発行'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
         assert '名称は必須です。'.encode('utf-8') in response.data
         assert '略称は必須です。'.encode('utf-8') in response.data
         assert '総発行量は必須です。'.encode('utf-8') in response.data
@@ -943,7 +943,7 @@ class TestBond(TestBase):
         assert '個人情報コントラクトアドレスは必須です。'.encode('utf-8') in response.data
 
     # ＜エラー系1＞
-    #   債券新規発行（アドレスのフォーマットエラー）
+    #   新規発行（アドレスのフォーマットエラー）
     def test_error_1_2(self, app):
         error_address = '0xc94b0d702422587e361dd6cd08b55dfe1961181f1'
 
@@ -980,7 +980,7 @@ class TestBond(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>債券新規発行'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
         assert 'DEXアドレスは有効なアドレスではありません。'.encode('utf-8') in response.data
 
     # ＜エラー系1＞
@@ -1001,7 +1001,7 @@ class TestBond(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>債券詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert 'DEXアドレスは有効なアドレスではありません。'.encode('utf-8') in response.data
         assert '個人情報コントラクトは有効なアドレスではありません。'.encode('utf-8') in response.data
 
@@ -1084,10 +1084,10 @@ class TestBond(TestBase):
             }
         )
         assert response.status_code == 302
-        # 債券新規売出でエラーを確認
+        # 新規売出でエラーを確認
         response = client.get(self.url_sell + token.token_address)
         assert response.status_code == 200
-        assert '<title>債券新規売出'.encode('utf-8') in response.data
+        assert '<title>新規売出'.encode('utf-8') in response.data
         assert '売出価格は必須です。'.encode('utf-8') in response.data
 
     # ＜エラー系3＞

--- a/app/tests/test_coupon.py
+++ b/app/tests/test_coupon.py
@@ -138,7 +138,7 @@ class TestCoupon(TestBase):
         # 発行済一覧の参照
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>クーポン一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert 'データが存在しません'.encode('utf-8') in response.data
 
     # ＜正常系1_2＞
@@ -186,7 +186,7 @@ class TestCoupon(TestBase):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>クーポン一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
 
     # ＜正常系2_3＞
     # ＜新規発行＞
@@ -201,7 +201,7 @@ class TestCoupon(TestBase):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_COUPON).order_by(Token.created).all()
         response = client.get(self.url_setting + tokens[0].token_address)
         assert response.status_code == 200
-        assert '<title>クーポン詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert 'テストクーポン'.encode('utf-8') in response.data
         assert 'COUPON'.encode('utf-8') in response.data
         assert '2000000'.encode('utf-8') in response.data
@@ -249,7 +249,7 @@ class TestCoupon(TestBase):
         response = client.get(self.url_setting + tokens[1].token_address)
 
         assert response.status_code == 200
-        assert '<title>クーポン詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert 'テストクーポン'.encode('utf-8') in response.data
         assert 'COUPON'.encode('utf-8') in response.data
         assert '2000000'.encode('utf-8') in response.data
@@ -272,8 +272,8 @@ class TestCoupon(TestBase):
         response = client.get(self.url_issue, )
         assert response.status_code == 200
 
-        assert '<title>クーポン発行'.encode('utf-8') in response.data
-        assert 'クーポン名'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
+        assert '名称'.encode('utf-8') in response.data
 
     # ＜正常系3_1＞
     # ＜1件確認＞
@@ -284,7 +284,7 @@ class TestCoupon(TestBase):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>クーポン一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert 'テストクーポン'.encode('utf-8') in response.data
         assert 'COUPON'.encode('utf-8') in response.data
         assert '取扱中'.encode('utf-8') in response.data
@@ -307,7 +307,7 @@ class TestCoupon(TestBase):
 
     # ＜正常系4＞
     # ＜設定変更＞
-    #   クーポン設定変更　→　詳細設定画面で確認
+    #   設定変更　→　詳細設定画面で確認
     def test_normal_4(self, app, shared_contract):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_COUPON).order_by(Token.created).all()
         url_setting = self.url_setting + tokens[0].token_address
@@ -332,7 +332,7 @@ class TestCoupon(TestBase):
 
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>クーポン詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert 'テストクーポン'.encode('utf-8') in response.data
         assert 'COUPON'.encode('utf-8') in response.data
         assert '2000000'.encode('utf-8') in response.data
@@ -382,7 +382,7 @@ class TestCoupon(TestBase):
         # 一覧で確認
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>クーポン一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert 'テストクーポン'.encode('utf-8') in response.data
         assert 'COUPON'.encode('utf-8') in response.data
         assert '停止中'.encode('utf-8') in response.data
@@ -406,7 +406,7 @@ class TestCoupon(TestBase):
         # 一覧で確認
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>クーポン一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert 'テストクーポン'.encode('utf-8') in response.data
         assert 'COUPON'.encode('utf-8') in response.data
         assert '取扱中'.encode('utf-8') in response.data
@@ -423,7 +423,7 @@ class TestCoupon(TestBase):
         # 追加発行画面（GET）
         response = client.get(url_add_supply)
         assert response.status_code == 200
-        assert '<title>クーポン追加発行'.encode('utf-8') in response.data
+        assert '<title>追加発行'.encode('utf-8') in response.data
         assert tokens[0].token_address.encode('utf-8') in response.data
         assert '2000000'.encode('utf-8') in response.data
 
@@ -439,13 +439,13 @@ class TestCoupon(TestBase):
         # 詳細設定画面で確認
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>クーポン詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert 'テストクーポン'.encode('utf-8') in response.data
         assert '2000100'.encode('utf-8') in response.data
 
     # ＜正常系7_1＞
     # ＜割当＞
-    #   クーポン割当　→　保有者一覧で確認
+    #   割当　→　保有者一覧で確認
     def test_normal_7_1(self, app):
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_COUPON).order_by(Token.created).all()
         client = self.client_with_admin_login(app)
@@ -464,7 +464,7 @@ class TestCoupon(TestBase):
         # 保有者一覧画面の参照
         response = client.get(self.url_holders + tokens[0].token_address)
         assert response.status_code == 200
-        assert '<title>クーポン保有者一覧'.encode('utf-8') in response.data
+        assert '<title>保有者一覧'.encode('utf-8') in response.data
 
         # 保有者一覧APIの参照
         response = client.get(self.url_get_holders + tokens[0].token_address)
@@ -499,14 +499,14 @@ class TestCoupon(TestBase):
 
     # ＜正常系7_2＞
     # ＜割当＞
-    #   クーポン割当画面表示
+    #   割当画面表示
     def test_normal_7_2(self, app):
         client = self.client_with_admin_login(app)
 
         # 割当処理
         response = client.get(self.url_transfer)
         assert response.status_code == 200
-        assert '<title>クーポン割当'.encode('utf-8') in response.data
+        assert '<title>トークン割当'.encode('utf-8') in response.data
 
     # ＜正常系8＞
     # ＜保有者詳細＞
@@ -641,7 +641,7 @@ class TestCoupon(TestBase):
         # 保有者一覧の参照
         response = client.get(self.url_holders + token.token_address)
         assert response.status_code == 200
-        assert '<title>クーポン保有者一覧'.encode('utf-8') in response.data
+        assert '<title>保有者一覧'.encode('utf-8') in response.data
 
         # 保有者一覧APIの参照
         response = client.get(self.url_get_holders + token.token_address)
@@ -696,7 +696,7 @@ class TestCoupon(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>クーポン詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '公開済'.encode('utf-8') in response.data
 
     # ＜正常系12_1＞
@@ -712,7 +712,7 @@ class TestCoupon(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>クーポン詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込開始'.encode('utf-8') in response.data
 
     # ＜正常系12_2＞
@@ -737,7 +737,7 @@ class TestCoupon(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>クーポン詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込停止'.encode('utf-8') in response.data
 
     # ＜正常系12_3＞
@@ -763,7 +763,7 @@ class TestCoupon(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>クーポン詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込開始'.encode('utf-8') in response.data
 
         # 募集申込状態に戻す
@@ -834,7 +834,7 @@ class TestCoupon(TestBase):
         url = self.url_allocate + '/' + token_address + '/' + trader_address
         response = client.get(url)
         assert response.status_code == 200
-        assert 'クーポン割当'.encode('utf-8') in response.data
+        assert 'トークン割当'.encode('utf-8') in response.data
         assert token_address.encode('utf-8') in response.data
         assert trader_address.encode('utf-8') in response.data
 
@@ -871,7 +871,7 @@ class TestCoupon(TestBase):
         # 保有者一覧の参照
         response = client.get(self.url_holders + token_address)
         assert response.status_code == 200
-        assert '<title>クーポン保有者一覧'.encode('utf-8') in response.data
+        assert '<title>保有者一覧'.encode('utf-8') in response.data
 
         # 保有者一覧APIの参照
         response = client.get(self.url_get_holders + token_address)
@@ -937,8 +937,8 @@ class TestCoupon(TestBase):
         assert tx_hash.encode('utf-8') in response.data
 
     # ＜正常系17_1＞
-    # ＜クーポン利用履歴画面＞
-    #   クーポン利用履歴画面が表示できること
+    # ＜利用履歴画面＞
+    #   利用履歴画面が表示できること
     def test_normal_17_1(self, app):
         client = self.client_with_admin_login(app)
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_COUPON).order_by(Token.created).all()
@@ -951,8 +951,8 @@ class TestCoupon(TestBase):
         assert response.status_code == 200
 
     # ＜正常系17_2＞
-    # ＜クーポン利用履歴（API）＞
-    #   クーポン利用履歴が取得できること（0件）
+    # ＜利用履歴（API）＞
+    #   利用履歴が取得できること（0件）
     def test_normal_17_2(self, app):
         client = self.client_with_admin_login(app)
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_COUPON).order_by(Token.created).all()
@@ -967,8 +967,8 @@ class TestCoupon(TestBase):
         assert len(response_data) == 0
 
     # ＜正常系17_3＞
-    # ＜クーポン利用履歴（API）＞
-    #   クーポン利用履歴が取得できること（1件）
+    # ＜利用履歴（API）＞
+    #   利用履歴が取得できること（1件）
     def test_normal_17_3(self, app, db):
         client = self.client_with_admin_login(app)
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_COUPON).order_by(Token.created).all()
@@ -1006,7 +1006,7 @@ class TestCoupon(TestBase):
 
     # ＜正常系17_4＞
     # ＜利用履歴CSVダウンロード＞
-    #   クーポン利用履歴CSVが取得できること
+    #   利用履歴CSVが取得できること
     def test_normal_17_4(self, app, db):
         client = self.client_with_admin_login(app)
         tokens = Token.query.filter_by(template_id=Config.TEMPLATE_ID_COUPON).order_by(Token.created).all()
@@ -1060,8 +1060,8 @@ class TestCoupon(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>クーポン発行'.encode('utf-8') in response.data
-        assert 'クーポン名は必須です。'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
+        assert '名称は必須です。'.encode('utf-8') in response.data
         assert '略称は必須です。'.encode('utf-8') in response.data
         assert '総発行量は必須です。'.encode('utf-8') in response.data
         assert 'DEXアドレスは必須です。'.encode('utf-8') in response.data
@@ -1078,7 +1078,7 @@ class TestCoupon(TestBase):
             data={}
         )
         assert response.status_code == 200
-        assert '<title>クーポン追加発行'.encode('utf-8') in response.data
+        assert '<title>追加発行'.encode('utf-8') in response.data
         assert '追加発行量は必須です。'.encode('utf-8') in response.data
 
     # ＜エラー系3＞
@@ -1090,8 +1090,8 @@ class TestCoupon(TestBase):
             data={}
         )
         assert response.status_code == 200
-        assert '<title>クーポン割当'.encode('utf-8') in response.data
-        assert 'クーポンアドレスは必須です。'.encode('utf-8') in response.data
+        assert '<title>トークン割当'.encode('utf-8') in response.data
+        assert 'トークンアドレスは必須です。'.encode('utf-8') in response.data
         assert '割当先アドレスは必須です。'.encode('utf-8') in response.data
         assert '割当数量は必須です。'.encode('utf-8') in response.data
 
@@ -1139,7 +1139,7 @@ class TestCoupon(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>クーポン発行'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
         assert 'DEXアドレスは有効なアドレスではありません。'.encode('utf-8') in response.data
 
     # ＜エラー系2_2＞
@@ -1175,7 +1175,7 @@ class TestCoupon(TestBase):
         # 追加発行画面（GET）
         response = client.get(url_add_supply)
         assert response.status_code == 200
-        assert '<title>クーポン追加発行'.encode('utf-8') in response.data
+        assert '<title>追加発行'.encode('utf-8') in response.data
         assert tokens[0].token_address.encode('utf-8') in response.data
         assert '2000100'.encode('utf-8') in response.data
 
@@ -1194,7 +1194,7 @@ class TestCoupon(TestBase):
         # 詳細設定画面で確認
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>クーポン詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert 'テストクーポン'.encode('utf-8') in response.data
         assert '2000100'.encode('utf-8') in response.data
 
@@ -1409,8 +1409,8 @@ class TestCoupon(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>クーポン割当'.encode('utf-8') in response.data
-        assert 'クーポンアドレスは有効なアドレスではありません。'.encode('utf-8') in response.data
+        assert '<title>トークン割当'.encode('utf-8') in response.data
+        assert 'トークンアドレスは有効なアドレスではありません。'.encode('utf-8') in response.data
 
     # ＜エラー系5_2＞
     #   割当（割当先アドレス形式エラー）
@@ -1427,7 +1427,7 @@ class TestCoupon(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>クーポン割当'.encode('utf-8') in response.data
+        assert '<title>トークン割当'.encode('utf-8') in response.data
         assert '割当先アドレスは有効なアドレスではありません。'.encode('utf-8') in response.data
 
     # ＜エラー系5_3＞
@@ -1445,7 +1445,7 @@ class TestCoupon(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>クーポン割当'.encode('utf-8') in response.data
+        assert '<title>トークン割当'.encode('utf-8') in response.data
         assert '割当数量は100,000,000が上限です。'.encode('utf-8') in response.data
 
     # ＜エラー系5_4＞
@@ -1465,11 +1465,11 @@ class TestCoupon(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>クーポン割当'.encode('utf-8') in response.data
+        assert '<title>トークン割当'.encode('utf-8') in response.data
         assert '割当数量が残高を超えています。'.encode('utf-8') in response.data
 
     # ＜エラー系5_5＞
-    #   割当（クーポンアドレスが無効）
+    #   割当（トークンアドレスが無効）
     def test_error_5_5(self, app):
         client = self.client_with_admin_login(app)
         response = client.post(
@@ -1481,8 +1481,8 @@ class TestCoupon(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>クーポン割当'.encode('utf-8') in response.data
-        assert '無効なクーポンアドレスです。'.encode('utf-8') in response.data
+        assert '<title>トークン割当'.encode('utf-8') in response.data
+        assert '無効なトークンアドレスです。'.encode('utf-8') in response.data
 
     # ＜エラー系6_1＞
     # ＜発行体相違＞
@@ -1692,7 +1692,7 @@ class TestCoupon(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '無効なクーポンアドレスです。'.encode('utf-8') in response.data
+        assert '無効なトークンアドレスです。'.encode('utf-8') in response.data
 
     # ＜エラー系6_10＞
     # ＜発行体相違＞

--- a/app/tests/test_membership.py
+++ b/app/tests/test_membership.py
@@ -194,7 +194,7 @@ class TestMembership(TestBase):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>会員権一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert 'データが存在しません'.encode('utf-8') in response.data
 
     # ＜正常系1_2＞
@@ -226,7 +226,7 @@ class TestMembership(TestBase):
         token = TestMembership.get_token(0)
         response = client.get(self.url_setting + token.token_address)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert self.token_data1['name'].encode('utf-8') in response.data
         assert self.token_data1['symbol'].encode('utf-8') in response.data
         assert str(self.token_data1['totalSupply']).encode('utf-8') in response.data
@@ -250,7 +250,7 @@ class TestMembership(TestBase):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>会員権一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert self.token_data1['name'].encode('utf-8') in response.data
         assert self.token_data1['symbol'].encode('utf-8') in response.data
         assert token.token_address.encode('utf-8') in response.data
@@ -273,7 +273,7 @@ class TestMembership(TestBase):
                    encode('utf-8') in response.data
 
     # ＜正常系3_1＞
-    # ＜会員権一覧（複数件）＞
+    # ＜発行済一覧（複数件）＞
     #   新規発行（画像URLなし）　→　詳細設定画面の参照
     def test_normal_3_1(self, app, db):
         client = self.client_with_admin_login(app)
@@ -292,7 +292,7 @@ class TestMembership(TestBase):
         token = TestMembership.get_token(1)
         response = client.get(self.url_setting + token.token_address)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert self.token_data2['name'].encode('utf-8') in response.data
         assert self.token_data2['symbol'].encode('utf-8') in response.data
         assert str(self.token_data2['totalSupply']).encode('utf-8') in response.data
@@ -306,7 +306,7 @@ class TestMembership(TestBase):
         assert self.token_data2['image_3'].encode('utf-8') in response.data
 
     # ＜正常系3_2＞
-    # ＜会員権一覧（複数件）＞
+    # ＜発行済一覧（複数件）＞
     #   発行済一覧画面の参照（複数件）
     def test_normal_3_2(self, app):
         token1 = TestMembership.get_token(0)
@@ -316,7 +316,7 @@ class TestMembership(TestBase):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>会員権一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
 
         # Token_1
         assert self.token_data1['name'].encode('utf-8') in response.data
@@ -330,7 +330,7 @@ class TestMembership(TestBase):
         assert token2.token_address.encode('utf-8') in response.data
 
     # ＜正常系3_3＞
-    # ＜会員権一覧（複数件）＞
+    # ＜発行済一覧（複数件）＞
     #   売出管理画面の参照（複数件）
     def test_normal_3_3(self, app):
         token1 = TestMembership.get_token(0)
@@ -454,7 +454,7 @@ class TestMembership(TestBase):
         # 詳細設定画面の参照
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert self.token_data3['name'].encode('utf-8') in response.data
         assert self.token_data3['symbol'].encode('utf-8') in response.data
         assert str(self.token_data3['totalSupply']).encode('utf-8') in response.data
@@ -494,7 +494,7 @@ class TestMembership(TestBase):
         # 詳細設定画面の参照
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert self.token_data1['name'].encode('utf-8') in response.data
         assert self.token_data1['symbol'].encode('utf-8') in response.data
         assert str(self.token_data1['totalSupply']).encode('utf-8') in response.data
@@ -531,7 +531,7 @@ class TestMembership(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '公開済'.encode('utf-8') in response.data
 
     # ＜正常系5_4＞
@@ -555,7 +555,7 @@ class TestMembership(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '公開済'.encode('utf-8') in response.data
         assert '取扱開始'.encode('utf-8') in response.data
 
@@ -585,7 +585,7 @@ class TestMembership(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '取扱停止'.encode('utf-8') in response.data
 
         # 発行済一覧画面の参照
@@ -619,7 +619,7 @@ class TestMembership(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert str(self.token_data1['totalSupply'] + 10).encode('utf-8') in response.data
 
     # ＜正常系6_1＞
@@ -831,7 +831,7 @@ class TestMembership(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込開始'.encode('utf-8') in response.data
 
     # ＜正常系8_2＞
@@ -855,7 +855,7 @@ class TestMembership(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込停止'.encode('utf-8') in response.data
 
     # ＜正常系8_3＞
@@ -880,7 +880,7 @@ class TestMembership(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>会員権詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込開始'.encode('utf-8') in response.data
 
         # 募集申込状態に戻す
@@ -946,7 +946,7 @@ class TestMembership(TestBase):
         url = self.url_allocate + '/' + token_address + '/' + trader_address
         response = client.get(url)
         assert response.status_code == 200
-        assert '会員権割当'.encode('utf-8') in response.data
+        assert 'トークン割当'.encode('utf-8') in response.data
         assert token_address.encode('utf-8') in response.data
         assert trader_address.encode('utf-8') in response.data
 
@@ -1139,7 +1139,7 @@ class TestMembership(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>会員権新規発行'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
         assert '名称は必須です。'.encode('utf-8') in response.data
         assert '略称は必須です。'.encode('utf-8') in response.data
         assert '総発行量は必須です。'.encode('utf-8') in response.data
@@ -1189,7 +1189,7 @@ class TestMembership(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>会員権新規発行'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
         assert 'DEXアドレスは有効なアドレスではありません。'.encode('utf-8') in response.data
 
     # ＜エラー系2_2＞

--- a/app/tests/test_share.py
+++ b/app/tests/test_share.py
@@ -114,7 +114,7 @@ class TestShare(TestBase):
             cipher.encrypt(json.dumps(trader_personal_info_json).encode('utf-8')))
 
     #############################################################################
-    # テスト用株式トークン情報
+    # テスト用トークン情報
     #############################################################################
     # Token_1：最初に新規発行されるトークン。
     token_data1 = {
@@ -225,18 +225,18 @@ class TestShare(TestBase):
     # テスト（正常系）
     #############################################################################
     # ＜正常系1_1＞
-    # ＜株式の0件確認＞
-    #   株式一覧の参照(0件)
+    # ＜トークンの0件確認＞
+    #   トークン一覧の参照(0件)
     def test_normal_1_1(self, app):
         # 証券一覧
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>株式一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert 'データが存在しません'.encode('utf-8') in response.data
 
     # ＜正常系1_2＞
-    # ＜株式の0件確認＞
+    # ＜トークンの0件確認＞
     #   新規発行画面表示
     def test_normal_1_2(self, app, db, shared_contract):
         client = self.client_with_admin_login(app)
@@ -244,10 +244,10 @@ class TestShare(TestBase):
         response = client.get(self.url_issue)
 
         assert response.status_code == 200
-        assert '<title>株式新規発行'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
 
     # ＜正常系2_1＞
-    # ＜株式の1件確認＞
+    # ＜トークンの1件確認＞
     #   新規発行　→　詳細設定画面の参照
     def test_normal_2_1(self, app, db, shared_contract):
         client = self.client_with_admin_login(app)
@@ -266,15 +266,15 @@ class TestShare(TestBase):
         token = TestShare.get_token(0)
         response = client.get(self.url_setting + token.token_address)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         for value in self.token_data1.values():
             assert str(value).encode('utf-8') in response.data
         # セレクトボックスのassert（譲渡制限）
         assert '<option selected value="True">なし</option>'.encode('utf-8') in response.data
 
     # ＜正常系2_2＞
-    # ＜株式の1件確認＞
-    #   株式一覧の参照(1件)
+    # ＜トークンの1件確認＞
+    #   トークン一覧の参照(1件)
     def test_normal_2_2(self, app):
         token = TestShare.get_token(0)
 
@@ -282,14 +282,14 @@ class TestShare(TestBase):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>株式一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
         assert self.token_data1['name'].encode('utf-8') in response.data
         assert self.token_data1['symbol'].encode('utf-8') in response.data
         assert token.token_address.encode('utf-8') in response.data
         assert '取扱中'.encode('utf-8') in response.data
 
     # ＜正常系3_1＞
-    # ＜株式一覧（複数件）＞
+    # ＜トークン一覧（複数件）＞
     #   新規発行（必須項目のみ）　→　詳細設定画面の参照
     def test_normal_3_1(self, app, db):
         client = self.client_with_admin_login(app)
@@ -308,7 +308,7 @@ class TestShare(TestBase):
         token = TestShare.get_token(1)
         response = client.get(self.url_setting + token.token_address)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         for value in self.token_data2.values():
             if value != '':
                 assert str(value).encode('utf-8') in response.data
@@ -327,7 +327,7 @@ class TestShare(TestBase):
         assert '<option selected value="False">あり</option>'.encode('utf-8') in response.data
 
     # ＜正常系3_2＞
-    # ＜株式一覧（複数件）＞
+    # ＜トークン一覧（複数件）＞
     #   発行済一覧画面の参照（複数件）
     def test_normal_3_2(self, app):
         token1 = TestShare.get_token(0)
@@ -337,7 +337,7 @@ class TestShare(TestBase):
         client = self.client_with_admin_login(app)
         response = client.get(self.url_list)
         assert response.status_code == 200
-        assert '<title>株式一覧'.encode('utf-8') in response.data
+        assert '<title>発行済一覧'.encode('utf-8') in response.data
 
         # Token_1
         assert self.token_data1['name'].encode('utf-8') in response.data
@@ -369,7 +369,7 @@ class TestShare(TestBase):
         # 詳細設定画面の参照
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert str(self.token_data3['dividends']).encode('utf-8') in response.data
         assert str(self.token_data3['dividendRecordDate']).encode('utf-8') in response.data
         assert str(self.token_data3['dividendPaymentDate']).encode('utf-8') in response.data
@@ -410,7 +410,7 @@ class TestShare(TestBase):
         # 詳細設定画面の参照
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         for value in self.token_data1.values():
             assert str(value).encode('utf-8') in response.data
         # セレクトボックスのassert（譲渡制限）
@@ -439,7 +439,7 @@ class TestShare(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '公開済'.encode('utf-8') in response.data
 
     # ＜正常系4_4＞
@@ -463,7 +463,7 @@ class TestShare(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '公開済'.encode('utf-8') in response.data
         assert '取扱開始'.encode('utf-8') in response.data
 
@@ -493,7 +493,7 @@ class TestShare(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '取扱停止'.encode('utf-8') in response.data
 
         # 発行済一覧画面の参照
@@ -527,7 +527,7 @@ class TestShare(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert str(self.token_data1['totalSupply'] + 10).encode('utf-8') in response.data
 
     # ＜正常系5_1＞
@@ -550,7 +550,7 @@ class TestShare(TestBase):
         # 保有者一覧の参照
         response = client.get(self.url_holders + token.token_address)
         assert response.status_code == 200
-        assert '<title>株式保有者一覧'.encode('utf-8') in response.data
+        assert '<title>保有者一覧'.encode('utf-8') in response.data
 
         # 保有者一覧APIの参照
         response = client.get(self.url_get_holders + token.token_address)
@@ -579,7 +579,7 @@ class TestShare(TestBase):
         client = self.client_with_admin_login(app)
         token = TestShare.get_token(0)
 
-        # 株式の売出
+        # トークンの売出
         exchange = shared_contract['IbetShareExchange']
         price = 100
         amount = 20
@@ -611,7 +611,7 @@ class TestShare(TestBase):
         # 保有者一覧の参照
         response = client.get(self.url_holders + token.token_address)
         assert response.status_code == 200
-        assert '<title>株式保有者一覧'.encode('utf-8') in response.data
+        assert '<title>保有者一覧'.encode('utf-8') in response.data
 
         # 保有者一覧APIの参照
         response = client.get(self.url_get_holders + token.token_address)
@@ -652,7 +652,7 @@ class TestShare(TestBase):
         # 保有者詳細画面の参照
         response = client.get(self.url_holder + token.token_address + '/' + eth_account['issuer']['account_address'])
         assert response.status_code == 200
-        assert '<title>株式保有者詳細'.encode('utf-8') in response.data
+        assert '<title>保有者詳細'.encode('utf-8') in response.data
         assert eth_account['issuer']['account_address'].encode('utf-8') in response.data
         assert '株式会社１'.encode('utf-8') in response.data
         assert '1234567'.encode('utf-8') in response.data
@@ -713,7 +713,7 @@ class TestShare(TestBase):
         # 保有者一覧の参照
         response = client.get(self.url_holders + token.token_address)
         assert response.status_code == 200
-        assert '<title>株式保有者一覧'.encode('utf-8') in response.data
+        assert '<title>保有者一覧'.encode('utf-8') in response.data
 
         # 保有者一覧APIの参照
         response = client.get(self.url_get_holders + token.token_address)
@@ -795,7 +795,7 @@ class TestShare(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込開始'.encode('utf-8') in response.data
 
     # ＜正常系7_2＞
@@ -819,7 +819,7 @@ class TestShare(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込停止'.encode('utf-8') in response.data
 
     # ＜正常系7_3＞
@@ -843,7 +843,7 @@ class TestShare(TestBase):
         url_setting = self.url_setting + token.token_address
         response = client.get(url_setting)
         assert response.status_code == 200
-        assert '<title>株式詳細設定'.encode('utf-8') in response.data
+        assert '<title>詳細設定'.encode('utf-8') in response.data
         assert '募集申込開始'.encode('utf-8') in response.data
 
         # 募集申込状態に戻す
@@ -1003,7 +1003,7 @@ class TestShare(TestBase):
         # 保有者一覧の参照
         response = client.get(self.url_holders + token_address)
         assert response.status_code == 200
-        assert '<title>株式保有者一覧'.encode('utf-8') in response.data
+        assert '<title>保有者一覧'.encode('utf-8') in response.data
 
         # 保有者一覧APIの参照
         response = client.get(self.url_get_holders + token.token_address)
@@ -1043,7 +1043,7 @@ class TestShare(TestBase):
         # 保有者一覧の参照
         response = client.get(self.url_holders_csv_history + token.token_address)
         assert response.status_code == 200
-        assert '<title>株式保有者リスト履歴'.encode('utf-8') in response.data
+        assert '<title>保有者リスト履歴'.encode('utf-8') in response.data
         assert token.token_address.encode('utf-8') in response.data
 
     # ＜正常系11-2＞
@@ -1113,7 +1113,7 @@ class TestShare(TestBase):
 
     # ＜エラー系1_1＞
     # ＜入力値チェック＞
-    #   株式新規発行（必須エラー）
+    #   新規発行（必須エラー）
     def test_error_1_1(self, app):
         client = self.client_with_admin_login(app)
         # 新規発行
@@ -1123,7 +1123,7 @@ class TestShare(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>株式新規発行'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
         assert '名称は必須です。'.encode('utf-8') in response.data
         assert '略称は必須です。'.encode('utf-8') in response.data
         assert '総発行量は必須です。'.encode('utf-8') in response.data
@@ -1151,7 +1151,7 @@ class TestShare(TestBase):
 
     # ＜エラー系2_1＞
     # ＜入力値チェック＞
-    #   株式新規発行（アドレスのフォーマットエラー）
+    #   新規発行（アドレスのフォーマットエラー）
     def test_error_2_1(self, app):
         error_address = '0xc94b0d702422587e361dd6cd08b55dfe1961181f1'
 
@@ -1166,7 +1166,7 @@ class TestShare(TestBase):
             }
         )
         assert response.status_code == 200
-        assert '<title>株式新規発行'.encode('utf-8') in response.data
+        assert '<title>新規発行'.encode('utf-8') in response.data
         assert 'DEXアドレスは有効なアドレスではありません。'.encode('utf-8') in response.data
         assert '個人情報コントラクトアドレスは有効なアドレスではありません。'.encode('utf-8') in response.data
 

--- a/app/tests/utils/contract_utils_coupon.py
+++ b/app/tests/utils/contract_utils_coupon.py
@@ -8,7 +8,7 @@ from app.utils import ContractUtils
 web3 = Web3(Web3.HTTPProvider(Config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
-# クーポン：募集申込
+# 募集申込
 def apply_for_offering(db, invoker, token_address):
     web3.eth.defaultAccount = invoker['account_address']
     TokenContract = ContractUtils.get_contract('IbetCoupon', token_address)

--- a/app/tests/utils/contract_utils_share.py
+++ b/app/tests/utils/contract_utils_share.py
@@ -10,7 +10,7 @@ web3 = Web3(Web3.HTTPProvider(Config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
 
-# 株式トークンの売出
+# SHAREトークンの売出
 def create_order(issuer, counterpart, share_exchange, token_address, amount, price, agent):
     web3.eth.defaultAccount = issuer['account_address']
     ShareContract = ContractUtils.get_contract('IbetShare', token_address)
@@ -43,7 +43,7 @@ def get_latest_agreementid(share_exchange, order_id):
     return latest_agreementid
 
 
-# 株式トークンの買いTake注文
+# SHAREトークンの買いTake注文
 def take_buy(invoker, share_exchange, order_id):
     web3.eth.defaultAccount = invoker['account_address']
     ExchangeContract = ContractUtils.get_contract('IbetOTCExchange', share_exchange['address'])
@@ -52,7 +52,7 @@ def take_buy(invoker, share_exchange, order_id):
     web3.eth.waitForTransactionReceipt(tx_hash)
 
 
-# 株式約定の資金決済
+# 約定の資金決済
 def confirm_agreement(invoker, share_exchange, order_id, agreement_id):
     web3.eth.defaultAccount = invoker['account_address']
     ExchangeContract = ContractUtils.get_contract(
@@ -64,7 +64,7 @@ def confirm_agreement(invoker, share_exchange, order_id, agreement_id):
     web3.eth.waitForTransactionReceipt(tx_hash)
 
 
-# 株式：募集申込
+# 募集申込
 def apply_for_offering(db, invoker, token_address):
     web3.eth.defaultAccount = invoker['account_address']
     TokenContract = ContractUtils.get_contract('IbetShare', token_address)

--- a/batch/indexer_Agreement.py
+++ b/batch/indexer_Agreement.py
@@ -151,15 +151,15 @@ class Processor:
                 continue
             if exchange_address not in exchange_address_list:
                 exchange_address_list.append(exchange_address)
-                if token.template_id == 1:  # 債券トークン
+                if token.template_id == 1:  # BONDトークン
                     self.exchange_list.append(
                         ContractUtils.get_contract('IbetStraightBondExchange', exchange_address)
                     )
-                elif token.template_id == 2:  # クーポントークン
+                elif token.template_id == 2:  # COUPONトークン
                     self.exchange_list.append(
                         ContractUtils.get_contract('IbetCouponExchange', exchange_address)
                     )
-                elif token.template_id == 3:  # 会員権トークン
+                elif token.template_id == 3:  # MEMBERSHIPトークン
                     self.exchange_list.append(
                         ContractUtils.get_contract('IbetMembershipExchange', exchange_address)
                     )

--- a/batch/indexer_Order.py
+++ b/batch/indexer_Order.py
@@ -141,15 +141,15 @@ class Processor:
                 continue
             if exchange_address not in exchange_address_list:
                 exchange_address_list.append(exchange_address)
-                if token.template_id == 1:  # 債券トークン
+                if token.template_id == 1:  # BONDトークン
                     self.exchange_list.append(
                         ContractUtils.get_contract('IbetStraightBondExchange', exchange_address)
                     )
-                elif token.template_id == 2:  # クーポントークン
+                elif token.template_id == 2:  # COUPONトークン
                     self.exchange_list.append(
                         ContractUtils.get_contract('IbetCouponExchange', exchange_address)
                     )
-                elif token.template_id == 3:  # 会員権トークン
+                elif token.template_id == 3:  # MEMBERSHIPトークン
                     self.exchange_list.append(
                         ContractUtils.get_contract('IbetMembershipExchange', exchange_address)
                     )

--- a/config.py
+++ b/config.py
@@ -28,10 +28,10 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
     # Tokenテーブルのtemplate_id
-    TEMPLATE_ID_SB = 1  # 債券
-    TEMPLATE_ID_COUPON = 2  # クーポン
-    TEMPLATE_ID_MEMBERSHIP = 3  # 会員権
-    TEMPLATE_ID_SHARE = 4  # 株式
+    TEMPLATE_ID_SB = 1  # BOND
+    TEMPLATE_ID_COUPON = 2  # COUPON
+    TEMPLATE_ID_MEMBERSHIP = 3  # MEMBERSHIP
+    TEMPLATE_ID_SHARE = 4  # SHARE
 
     # gunicornのworker数
     WORKER_COUNT = int(os.environ.get("WORKER_COUNT")) if os.environ.get("WORKER_COUNT") else 4
@@ -75,24 +75,24 @@ class Config:
     }
 
     NAVI_MENU_USER = [
-        ('share', 'glyphicon glyphicon-th', '株式', [
+        ('share', 'glyphicon glyphicon-th', 'SHARE', [
             ('share_issue', 'fa fa-circle-o', '新規発行', 'share.issue'),
             ('share_list', 'fa fa-circle-o', '発行済一覧', 'share.list'),
             ('share_bulk_transfer', 'fa fa-circle-o', '一括強制移転', 'share.bulk_transfer')
         ]),
-        ('bond', 'glyphicon glyphicon-th', '債券', [
+        ('bond', 'glyphicon glyphicon-th', 'BOND', [
             ('bond_issue', 'fa fa-circle-o', '新規発行', 'bond.issue'),
             ('bond_list', 'fa fa-circle-o', '発行済一覧', 'bond.list'),
             ('bond_position', 'fa fa-circle-o', '売出管理', 'bond.positions'),
             ('bond_bulk_transfer', 'fa fa-circle-o', '一括強制移転', 'bond.bulk_transfer')
         ]),
-        ('membership', 'glyphicon glyphicon-th', '会員権', [
+        ('membership', 'glyphicon glyphicon-th', 'MEMBERSHIP', [
             ('membership_issue', 'fa fa-circle-o', '新規発行', 'membership.issue'),
             ('membership_list', 'fa fa-circle-o', '発行済一覧', 'membership.list'),
             ('membership_position', 'fa fa-circle-o', '売出管理', 'membership.positions'),
             ('membership_bulk_transfer', 'fa fa-circle-o', '一括強制移転', 'membership.bulk_transfer')
         ]),
-        ('coupon', 'glyphicon glyphicon-th', 'クーポン', [
+        ('coupon', 'glyphicon glyphicon-th', 'COUPON', [
             ('coupon_issue', 'fa fa-circle-o', '新規発行', 'coupon.issue'),
             ('coupon_list', 'fa fa-circle-o', '発行済一覧', 'coupon.list'),
             ('coupon_position', 'fa fa-circle-o', '売出管理', 'coupon.positions'),


### PR DESCRIPTION
#725 related.

- Due to the expansion of supported product types, the name of the token type displayed in the application has been changed.

![image](https://user-images.githubusercontent.com/963333/116404393-8ae18500-a869-11eb-984c-cc8fdb53a6c2.png)
